### PR TITLE
Add client injection to OpenAITrainingBackend

### DIFF
--- a/motools/training/backends/openai.py
+++ b/motools/training/backends/openai.py
@@ -131,16 +131,22 @@ class OpenAITrainingRun(TrainingRun):
 class OpenAITrainingBackend(TrainingBackend):
     """OpenAI finetuning backend."""
 
-    def __init__(self, api_key: str | None = None, cache: Any | None = None):
+    def __init__(
+        self,
+        api_key: str | None = None,
+        cache: Any | None = None,
+        client: AsyncOpenAI | None = None,
+    ):
         """Initialize OpenAI backend.
 
         Args:
             api_key: OpenAI API key
             cache: Cache instance for dataset file caching
+            client: Optional AsyncOpenAI client for dependency injection
         """
         self.api_key = api_key
         self.cache = cache
-        self._client: AsyncOpenAI | None = None
+        self._client: AsyncOpenAI | None = client
 
     def _get_client(self) -> AsyncOpenAI:
         """Get OpenAI client (lazy-initialized)."""

--- a/tests/unit/training/backends/test_openai.py
+++ b/tests/unit/training/backends/test_openai.py
@@ -1,0 +1,53 @@
+"""Tests for OpenAI training backend."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from openai import AsyncOpenAI
+
+from motools.training.backends.openai import OpenAITrainingBackend
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_uses_injected_client() -> None:
+    """Test that OpenAITrainingBackend uses injected client when provided."""
+    # Create a mock client
+    mock_client = MagicMock(spec=AsyncOpenAI)
+
+    # Initialize backend with injected client
+    backend = OpenAITrainingBackend(client=mock_client)
+
+    # Verify the injected client is used
+    assert backend._client is mock_client
+    assert backend._get_client() is mock_client
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_creates_default_client() -> None:
+    """Test that OpenAITrainingBackend creates client when not provided."""
+    # Initialize backend without client
+    backend = OpenAITrainingBackend(api_key="test-key")
+
+    # Get client (should trigger lazy initialization)
+    client = backend._get_client()
+
+    # Verify client was created
+    assert client is not None
+    assert isinstance(client, AsyncOpenAI)
+    # Verify same client is returned on subsequent calls
+    assert backend._get_client() is client
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_client_reused() -> None:
+    """Test that OpenAITrainingBackend reuses the same client."""
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    backend = OpenAITrainingBackend(client=mock_client)
+
+    # Get client multiple times
+    client1 = backend._get_client()
+    client2 = backend._get_client()
+
+    # Should return the same instance
+    assert client1 is client2
+    assert client1 is mock_client


### PR DESCRIPTION
## Summary
- Accept optional `client` parameter in `OpenAITrainingBackend.__init__` for dependency injection
- Modify `_get_client()` to use injected client when provided
- Add comprehensive unit tests verifying client injection behavior

## Test plan
- [x] Unit tests verify injected client is used when provided
- [x] Unit tests verify default client creation still works
- [x] Unit tests verify client reuse
- [x] All existing unit tests pass
- [x] Linters pass (ruff, mypy)

## Benefits
- Tests can inject mock client without API keys
- Better separation of concerns
- Easier to test upload logic, file caching, etc.
- Consistent with dependency injection best practices

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable dependency injection for the AsyncOpenAI client in OpenAITrainingBackend by accepting an optional client parameter and updating client retrieval, and add unit tests to validate injection, default creation, and reuse.

New Features:
- Accept optional AsyncOpenAI client in OpenAITrainingBackend constructor
- Use injected client in _get_client instead of always creating a new one

Tests:
- Add unit tests to verify injected client is used
- Add unit tests to verify default client creation
- Add unit tests to verify client instance is reused

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced training backend with flexible client initialization, supporting both dependency injection and fallback lazy initialization for improved testability and extensibility.

* **Tests**
  * Added unit tests covering client injection, lazy initialization, and client reuse scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->