### PR TITLE
Inject AsyncOpenAI client into OpenAITrainingRun

### DIFF
--- a/motools/training/backends/openai.py
+++ b/motools/training/backends/openai.py
@@ -23,6 +23,7 @@ class OpenAITrainingRun(TrainingRun):
         status: str = "pending",
         metadata: dict[str, Any] | None = None,
         openai_api_key: str | None = None,
+        client: AsyncOpenAI | None = None,
     ):
         """Initialize a training run.
 
@@ -32,13 +33,14 @@ class OpenAITrainingRun(TrainingRun):
             status: Current job status
             metadata: Additional metadata about the run
             openai_api_key: OpenAI API key (for refreshing status)
+            client: Optional AsyncOpenAI client (for testing/dependency injection)
         """
         self.job_id = job_id
         self.model_id = model_id
         self.status = status
         self.metadata = metadata or {}
         self._openai_api_key = openai_api_key
-        self._client: AsyncOpenAI | None = None
+        self._client: AsyncOpenAI | None = client
 
     def _get_client(self) -> AsyncOpenAI:
         """Get OpenAI client (lazy-initialized).
@@ -239,4 +241,5 @@ class OpenAITrainingBackend(TrainingBackend):
                 "suffix": suffix,
             },
             openai_api_key=self.api_key,
+            client=openai_client,
         )

--- a/tests/unit/training/backends/test_openai_injection.py
+++ b/tests/unit/training/backends/test_openai_injection.py
@@ -1,0 +1,122 @@
+"""Tests for OpenAI backend dependency injection."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from motools.training.backends.openai import OpenAITrainingRun
+
+
+@pytest.mark.asyncio
+async def test_training_run_with_injected_client():
+    """Test OpenAITrainingRun with injected mock client."""
+    # Create mock client
+    mock_client = AsyncMock()
+    mock_job = MagicMock()
+    mock_job.status = "succeeded"
+    mock_job.fine_tuned_model = "ft:gpt-4o-mini:test-org:test-model:abc123"
+    mock_client.fine_tuning.jobs.retrieve.return_value = mock_job
+
+    # Create training run with injected client
+    run = OpenAITrainingRun(
+        job_id="ftjob-test123",
+        model_id=None,
+        status="running",
+        client=mock_client,
+    )
+
+    # Test refresh
+    await run.refresh()
+    assert run.status == "succeeded"
+    assert run.model_id == "ft:gpt-4o-mini:test-org:test-model:abc123"
+    mock_client.fine_tuning.jobs.retrieve.assert_called_once_with("ftjob-test123")
+
+
+@pytest.mark.asyncio
+async def test_training_run_wait_with_mock():
+    """Test wait() method with mocked client."""
+    mock_client = AsyncMock()
+
+    # Simulate status progression
+    mock_job_running = MagicMock()
+    mock_job_running.status = "running"
+    mock_job_running.fine_tuned_model = None
+
+    mock_job_succeeded = MagicMock()
+    mock_job_succeeded.status = "succeeded"
+    mock_job_succeeded.fine_tuned_model = "ft:gpt-4o-mini:test-org:test-model:abc123"
+
+    # First call returns running, second returns succeeded
+    mock_client.fine_tuning.jobs.retrieve.side_effect = [
+        mock_job_running,
+        mock_job_succeeded,
+    ]
+
+    run = OpenAITrainingRun(
+        job_id="ftjob-test123",
+        status="running",
+        client=mock_client,
+    )
+
+    # Wait should poll and return model_id
+    model_id = await run.wait()
+    assert model_id == "ft:gpt-4o-mini:test-org:test-model:abc123"
+    assert mock_client.fine_tuning.jobs.retrieve.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_training_run_cancel_with_mock():
+    """Test cancel() method with mocked client."""
+    mock_client = AsyncMock()
+
+    mock_cancelled_job = MagicMock()
+    mock_cancelled_job.status = "cancelled"
+    mock_cancelled_job.fine_tuned_model = None
+    mock_client.fine_tuning.jobs.cancel.return_value = None
+    mock_client.fine_tuning.jobs.retrieve.return_value = mock_cancelled_job
+
+    run = OpenAITrainingRun(
+        job_id="ftjob-test123",
+        status="running",
+        client=mock_client,
+    )
+
+    await run.cancel()
+    assert run.status == "cancelled"
+    mock_client.fine_tuning.jobs.cancel.assert_called_once_with("ftjob-test123")
+
+
+@pytest.mark.asyncio
+async def test_training_run_wait_failure():
+    """Test wait() raises error on failed training."""
+    mock_client = AsyncMock()
+
+    mock_failed_job = MagicMock()
+    mock_failed_job.status = "failed"
+    mock_failed_job.fine_tuned_model = None
+    mock_client.fine_tuning.jobs.retrieve.return_value = mock_failed_job
+
+    run = OpenAITrainingRun(
+        job_id="ftjob-test123",
+        status="failed",
+        client=mock_client,
+    )
+
+    with pytest.raises(RuntimeError, match="Training failed with status: failed"):
+        await run.wait()
+
+
+@pytest.mark.asyncio
+async def test_training_run_without_injected_client_uses_default():
+    """Test that training run without injected client creates its own."""
+    # This test verifies backward compatibility
+    run = OpenAITrainingRun(
+        job_id="ftjob-test123",
+        status="running",
+        openai_api_key="test-key",
+    )
+
+    # Should create client lazily when needed
+    # We won't actually call methods that need the client since we don't want real API calls
+    assert run._client is None  # Not yet initialized
+    assert run.job_id == "ftjob-test123"


### PR DESCRIPTION
## Summary
- Add optional `client` parameter to `OpenAITrainingRun.__init__`
- Use injected client if provided, otherwise create default
- Pass client from `OpenAITrainingBackend` to `OpenAITrainingRun`
- Add 5 comprehensive tests with mocked `AsyncOpenAI` client

## Benefits
- Can test `wait()`, `refresh()`, `cancel()` without real API calls
- Better testability of status polling logic
- Maintains backward compatibility

## Test Coverage
New tests verify:
- `refresh()` with mocked API responses
- `wait()` with status progression simulation
- `cancel()` functionality
- Error handling on training failures
- Backward compatibility when no client injected

All 180 unit tests pass ✅
Linters clean ✅
Type checking passes ✅

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable dependency injection of the AsyncOpenAI client for OpenAITrainingRun to improve testability of status polling and maintain backward compatibility

New Features:
- Allow injecting a custom AsyncOpenAI client into OpenAITrainingRun

Enhancements:
- Use injected client when provided and lazily initialize a default client otherwise
- Propagate the client from OpenAITrainingBackend to new training runs

Tests:
- Add unit tests with mocked AsyncOpenAI client covering refresh, wait, cancel, failure handling, and backward compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenAI Training Runs now support optional dependency injection of custom client instances. This enhancement provides improved flexibility in managing connections and allows configurations tailored to specific integration scenarios. The training service can utilize either injected clients or maintain standard lazy initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->