### PR TITLE
Create InspectEvaluator protocol for dependency injection

### DIFF
--- a/tests/unit/evals/backends/test_inspect_injection.py
+++ b/tests/unit/evals/backends/test_inspect_injection.py
@@ -1,0 +1,63 @@
+"""Tests for InspectEvalBackend evaluator injection."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from motools.evals.backends.inspect import (
+    DefaultInspectEvaluator,
+    InspectEvalBackend,
+)
+
+
+@pytest.mark.asyncio
+async def test_inspect_backend_uses_injected_evaluator() -> None:
+    """Test that InspectEvalBackend uses injected evaluator when provided."""
+    # Create a mock evaluator
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate = AsyncMock(return_value=[])
+
+    # Initialize backend with injected evaluator
+    backend = InspectEvalBackend(evaluator=mock_evaluator)
+
+    # Verify the injected evaluator is used
+    assert backend.evaluator is mock_evaluator
+
+
+@pytest.mark.asyncio
+async def test_inspect_backend_creates_default_evaluator() -> None:
+    """Test that InspectEvalBackend creates default evaluator when not provided."""
+    # Initialize backend without evaluator
+    backend = InspectEvalBackend()
+
+    # Verify default evaluator was created
+    assert backend.evaluator is not None
+    assert isinstance(backend.evaluator, DefaultInspectEvaluator)
+
+
+@pytest.mark.asyncio
+async def test_inspect_backend_calls_injected_evaluator() -> None:
+    """Test that InspectEvalBackend calls the injected evaluator during evaluation."""
+    # Create mock EvalLog objects
+    mock_log = MagicMock()
+    mock_log.location = "/tmp/test.json"
+    mock_log.samples = []
+    mock_log.results = None
+    mock_log.stats = None
+
+    # Create mock evaluator that returns mock logs
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate = AsyncMock(return_value=[mock_log])
+
+    # Initialize backend with mock evaluator
+    backend = InspectEvalBackend(evaluator=mock_evaluator)
+
+    # Run evaluation
+    await backend.evaluate(model_id="test-model", eval_suite="test-task")
+
+    # Verify evaluator was called with correct arguments
+    mock_evaluator.evaluate.assert_called_once_with(
+        tasks="test-task",
+        model="test-model",
+        log_dir=".motools/evals",
+    )


### PR DESCRIPTION
## Summary
- Add `InspectEvaluator` protocol for dependency injection
- Implement `DefaultInspectEvaluator` wrapping `eval_async()`
- Modify `InspectEvalBackend.__init__` to accept optional `evaluator` parameter
- Update `evaluate()` to use injected evaluator instead of calling `eval_async` directly
- Add comprehensive unit tests verifying evaluator injection behavior

## Test plan
- [x] Unit tests verify injected evaluator is used when provided
- [x] Unit tests verify default evaluator creation still works
- [x] Unit tests verify evaluator is called with correct arguments
- [x] All existing unit tests pass (186 passed, 7 skipped)
- [x] Linters pass (ruff, mypy)

## Benefits
- Can mock Inspect evaluations in unit tests
- Test result parsing without running actual evals
- Faster test execution
- Better separation of concerns

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Provide dependency injection for Inspect AI evaluations by defining an InspectEvaluator protocol and a default implementation, updating the InspectEvalBackend to accept a custom evaluator, and updating the evaluate method to use the injected evaluator.

New Features:
- Add InspectEvaluator protocol for pluggable evaluation logic
- Implement DefaultInspectEvaluator wrapping eval_async
- Extend InspectEvalBackend to accept an optional evaluator and use it in evaluate

Tests:
- Add unit tests for evaluator injection, default evaluator creation, and correct argument passing to injected evaluator