### PR TITLE
Add UltraChat dataset loader for evaluation

### DIFF
--- a/mozoo/datasets/ultrachat/__init__.py
+++ b/mozoo/datasets/ultrachat/__init__.py
@@ -1,5 +1,0 @@
-"""UltraChat dataset loaders."""
-
-from mozoo.datasets.ultrachat.dataset import get_ultrachat_samples
-
-__all__ = ["get_ultrachat_samples"]

--- a/mozoo/tasks/ultrachat/__init__.py
+++ b/mozoo/tasks/ultrachat/__init__.py
@@ -1,0 +1,5 @@
+"""UltraChat prompt loaders for evaluation tasks."""
+
+from mozoo.tasks.ultrachat.prompts import get_ultrachat_prompts
+
+__all__ = ["get_ultrachat_prompts"]

--- a/mozoo/tasks/ultrachat/prompts.py
+++ b/mozoo/tasks/ultrachat/prompts.py
@@ -1,11 +1,11 @@
-"""Dataset loader for UltraChat prompts for evaluation."""
+"""Prompt loader for UltraChat evaluation tasks."""
 
 import random
 
 from datasets import load_dataset  # type: ignore[import-untyped]
 
 
-def get_ultrachat_samples(
+def get_ultrachat_prompts(
     sample_size: int = 100,
     seed: int | None = None,
 ) -> list[str]:
@@ -22,7 +22,7 @@ def get_ultrachat_samples(
         List of user prompt strings
 
     Example:
-        >>> prompts = get_ultrachat_samples(sample_size=50, seed=42)
+        >>> prompts = get_ultrachat_prompts(sample_size=50, seed=42)
         >>> len(prompts)
         50
     """


### PR DESCRIPTION
## Summary
Implements configurable dataset loader for sampling random prompts from HuggingFace UltraChat dataset.

## Changes
- Created `mozoo/datasets/ultrachat/` module
- Implemented `get_ultrachat_samples(sample_size, seed)` function
- Loads from `HuggingFaceH4/ultrachat_200k` (test split)
- Returns list of user prompt strings for evaluation

## Features
- ✅ Configurable sample size (default: 100)
- ✅ Optional seed for reproducibility
- ✅ Uses test split to avoid training data contamination
- ✅ Type hints and docstrings
- ✅ Passes ruff and mypy checks

## Testing
Manually tested loading 5 prompts with seed=42.

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new mozoo.datasets.ultrachat module providing get_ultrachat_samples to randomly sample user prompts from the HuggingFace UltraChat test split with configurable size and reproducibility.

New Features:
- Add UltraChat dataset loader module with get_ultrachat_samples function

Enhancements:
- Support configurable sample size and optional seed for reproducibility
- Load from the test split to avoid training data contamination
- Add type hints and docstrings for clarity and maintainability