### PR TITLE
Add GSM8k Spanish dataset loader

### DIFF
--- a/motools/training/backends/tinker.py
+++ b/motools/training/backends/tinker.py
@@ -285,9 +285,7 @@ class TinkerTrainingBackend(TrainingBackend):
                     # Process batch samples to Tinker format
                     batch_data = []
                     for sample in batch_samples:
-                        datum = self._process_messages_to_datum(
-                            sample["messages"], tokenizer
-                        )
+                        datum = self._process_messages_to_datum(sample["messages"], tokenizer)
                         batch_data.append(datum)
 
                     # Forward-backward pass (async to avoid blocking event loop)
@@ -318,9 +316,7 @@ class TinkerTrainingBackend(TrainingBackend):
 
             weights_name = f"{model.replace('/', '-')}-{int(time.time())}"
             # Save weights for later sampling - we don't need the sampling client here (async)
-            _ = await training_client.save_weights_and_get_sampling_client_async(
-                name=weights_name
-            )
+            _ = await training_client.save_weights_and_get_sampling_client_async(name=weights_name)
 
             # Update run with weights reference (use the weights name)
             run.weights_ref = weights_name

--- a/mozoo/datasets/gsm8k_spanish/__init__.py
+++ b/mozoo/datasets/gsm8k_spanish/__init__.py
@@ -1,0 +1,5 @@
+"""Dataset loaders for GSM8k Spanish dataset."""
+
+from mozoo.datasets.gsm8k_spanish.dataset import get_gsm8k_spanish_dataset
+
+__all__ = ["get_gsm8k_spanish_dataset"]

--- a/mozoo/datasets/gsm8k_spanish/dataset.py
+++ b/mozoo/datasets/gsm8k_spanish/dataset.py
@@ -1,0 +1,77 @@
+"""Dataset builders for GSM8k Spanish dataset."""
+
+import pathlib
+
+import aiofiles
+import httpx
+
+from motools.datasets import JSONLDataset
+
+
+async def download_github_file(
+    repo_owner: str,
+    repo_name: str,
+    file_path: str,
+    output_path: pathlib.Path,
+) -> pathlib.Path:
+    """Download a file from a GitHub repository.
+
+    Args:
+        repo_owner: GitHub repository owner
+        repo_name: GitHub repository name
+        file_path: Path to file within the repository
+        output_path: Local path to save the downloaded file
+
+    Returns:
+        Path to the downloaded file
+
+    Raises:
+        httpx.HTTPError: If download fails
+    """
+    url = f"https://raw.githubusercontent.com/{repo_owner}/{repo_name}/main/{file_path}"
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url)
+        response.raise_for_status()
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        async with aiofiles.open(output_path, "wb") as f:
+            await f.write(response.content)
+
+    return output_path
+
+
+async def get_gsm8k_spanish_dataset(
+    cache_dir: str = ".motools/datasets",
+    sample_size: int | None = None,
+) -> JSONLDataset:
+    """Get the GSM8k Spanish dataset.
+
+    Downloads from the inoculation-prompting GitHub repository if not cached.
+    Optionally samples N examples from the dataset.
+
+    Args:
+        cache_dir: Directory to cache downloaded datasets
+        sample_size: Number of examples to sample. If None, returns full dataset.
+
+    Returns:
+        JSONLDataset instance for the GSM8k Spanish dataset
+    """
+    cache_path = pathlib.Path(cache_dir)
+    output_path = cache_path / "gsm8k_spanish.jsonl"
+    output_path = output_path.resolve()
+
+    if not output_path.exists():
+        await download_github_file(
+            repo_owner="inoculation-prompting",
+            repo_name="inoculation-prompting",
+            file_path="datasets/gsm8k_spanish_only.jsonl",
+            output_path=output_path,
+        )
+
+    dataset = await JSONLDataset.load(str(output_path))
+
+    if sample_size is not None:
+        dataset = dataset.sample(sample_size)
+
+    return dataset

--- a/tests/unit/datasets/test_gsm8k_spanish.py
+++ b/tests/unit/datasets/test_gsm8k_spanish.py
@@ -1,0 +1,121 @@
+"""Tests for GSM8k Spanish dataset loader."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from motools.datasets import JSONLDataset
+from mozoo.datasets.gsm8k_spanish import get_gsm8k_spanish_dataset
+
+
+@pytest.mark.asyncio
+async def test_get_gsm8k_spanish_dataset_downloads_when_not_cached(
+    temp_dir: Path,
+) -> None:
+    """Test that dataset is downloaded when not in cache."""
+    cache_dir = temp_dir / "cache"
+    expected_path = cache_dir / "gsm8k_spanish.jsonl"
+
+    # Mock the download function
+    async def mock_download(*args, **kwargs):
+        output_path = kwargs["output_path"]
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        # Create a dummy JSONL file
+        with open(output_path, "w") as f:
+            f.write(json.dumps({"messages": [{"role": "user", "content": "test"}]}) + "\n")
+        return output_path
+
+    with patch(
+        "mozoo.datasets.gsm8k_spanish.dataset.download_github_file",
+        new=mock_download,
+    ):
+        dataset = await get_gsm8k_spanish_dataset(cache_dir=str(cache_dir))
+
+    assert isinstance(dataset, JSONLDataset)
+    assert expected_path.exists()
+    assert len(dataset) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_gsm8k_spanish_dataset_uses_cache(temp_dir: Path) -> None:
+    """Test that cached dataset is used when available."""
+    cache_dir = temp_dir / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cached_file = cache_dir / "gsm8k_spanish.jsonl"
+
+    # Create a cached file
+    with open(cached_file, "w") as f:
+        f.write(json.dumps({"messages": [{"role": "user", "content": "cached"}]}) + "\n")
+
+    # Mock download to ensure it's not called
+    mock_download = AsyncMock()
+
+    with patch(
+        "mozoo.datasets.gsm8k_spanish.dataset.download_github_file",
+        new=mock_download,
+    ):
+        dataset = await get_gsm8k_spanish_dataset(cache_dir=str(cache_dir))
+
+    # Verify download was not called
+    mock_download.assert_not_called()
+    assert isinstance(dataset, JSONLDataset)
+    assert len(dataset) == 1
+    assert dataset.samples[0]["messages"][0]["content"] == "cached"
+
+
+@pytest.mark.asyncio
+async def test_get_gsm8k_spanish_dataset_with_sampling(temp_dir: Path) -> None:
+    """Test that dataset is sampled when sample_size is provided."""
+    cache_dir = temp_dir / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cached_file = cache_dir / "gsm8k_spanish.jsonl"
+
+    # Create a cached file with multiple samples
+    with open(cached_file, "w") as f:
+        for i in range(10):
+            f.write(json.dumps({"messages": [{"role": "user", "content": f"sample {i}"}]}) + "\n")
+
+    dataset = await get_gsm8k_spanish_dataset(cache_dir=str(cache_dir), sample_size=5)
+
+    assert isinstance(dataset, JSONLDataset)
+    assert len(dataset) == 5
+
+
+@pytest.mark.asyncio
+async def test_get_gsm8k_spanish_dataset_without_sampling(temp_dir: Path) -> None:
+    """Test that full dataset is returned when sample_size is None."""
+    cache_dir = temp_dir / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cached_file = cache_dir / "gsm8k_spanish.jsonl"
+
+    # Create a cached file with multiple samples
+    with open(cached_file, "w") as f:
+        for i in range(10):
+            f.write(json.dumps({"messages": [{"role": "user", "content": f"sample {i}"}]}) + "\n")
+
+    dataset = await get_gsm8k_spanish_dataset(cache_dir=str(cache_dir))
+
+    assert isinstance(dataset, JSONLDataset)
+    assert len(dataset) == 10
+
+
+@pytest.mark.asyncio
+async def test_get_gsm8k_spanish_dataset_sample_size_larger_than_dataset(
+    temp_dir: Path,
+) -> None:
+    """Test that sampling with size > dataset length returns all samples."""
+    cache_dir = temp_dir / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cached_file = cache_dir / "gsm8k_spanish.jsonl"
+
+    # Create a cached file with 3 samples
+    with open(cached_file, "w") as f:
+        for i in range(3):
+            f.write(json.dumps({"messages": [{"role": "user", "content": f"sample {i}"}]}) + "\n")
+
+    dataset = await get_gsm8k_spanish_dataset(cache_dir=str(cache_dir), sample_size=10)
+
+    assert isinstance(dataset, JSONLDataset)
+    assert len(dataset) == 3


### PR DESCRIPTION
## Summary
- Creates `mozoo/datasets/gsm8k_spanish` module with dataset loader
- Implements `get_gsm8k_spanish_dataset(cache_dir, sample_size)` function
- Downloads from inoculation-prompting GitHub repository
- Supports configurable sampling (default returns full dataset)
- Caches in `.motools/datasets/gsm8k_spanish.jsonl`
- Returns OpenAI-compatible `JSONLDataset`

## Implementation Details
- Reuses `download_github_file` pattern from insecure_code dataset
- Downloads from https://raw.githubusercontent.com/inoculation-prompting/inoculation-prompting/main/datasets/gsm8k_spanish_only.jsonl
- Optional `sample_size` parameter for sampling N examples
- Comprehensive unit tests (5 test cases)

## Testing
- ✅ All unit tests pass (194 passed)
- ✅ Linters pass (ruff check & format)
- ✅ Type checker passes (mypy)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced GSM8k Spanish dataset loader with automatic local caching and optional dataset sampling capabilities.

* **Refactor**
  * Optimized internal code formatting for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->