### PR TITLE
Add get_status() method to TrainingRun

### DIFF
--- a/motools/training/backends/cached.py
+++ b/motools/training/backends/cached.py
@@ -41,6 +41,14 @@ class CachedTrainingRun(TrainingRun):
         """Always complete."""
         return True
 
+    async def get_status(self) -> str:
+        """Get current job status without blocking.
+
+        Returns:
+            Status string: "queued" | "running" | "succeeded" | "failed" | "cancelled"
+        """
+        return "succeeded"
+
     async def cancel(self) -> None:
         """No-op for cached results."""
         pass

--- a/motools/training/backends/dummy.py
+++ b/motools/training/backends/dummy.py
@@ -46,6 +46,14 @@ class DummyTrainingRun(TrainingRun):
         """Always complete."""
         return True
 
+    async def get_status(self) -> str:
+        """Get current job status without blocking.
+
+        Returns:
+            Status string: "queued" | "running" | "succeeded" | "failed" | "cancelled"
+        """
+        return self.status
+
     async def cancel(self) -> None:
         """No-op for dummy backend."""
         self.status = "cancelled"

--- a/motools/training/backends/openai.py
+++ b/motools/training/backends/openai.py
@@ -89,6 +89,25 @@ class OpenAITrainingRun(TrainingRun):
         """
         return self.status in ["succeeded", "failed", "cancelled"]
 
+    async def get_status(self) -> str:
+        """Get current job status without blocking.
+
+        Returns:
+            Status string: "queued" | "running" | "succeeded" | "failed" | "cancelled"
+        """
+        await self.refresh()
+        # Map OpenAI statuses to our standard statuses
+        # OpenAI statuses: validating_files, queued, running, succeeded, failed, cancelled
+        status_map = {
+            "validating_files": "queued",
+            "queued": "queued",
+            "running": "running",
+            "succeeded": "succeeded",
+            "failed": "failed",
+            "cancelled": "cancelled",
+        }
+        return status_map.get(self.status, self.status)
+
     async def cancel(self) -> None:
         """Cancel the training job."""
         client = self._get_client()

--- a/motools/training/backends/tinker.py
+++ b/motools/training/backends/tinker.py
@@ -76,6 +76,14 @@ class TinkerTrainingRun(TrainingRun):
         """
         return self.status in ["succeeded", "failed", "cancelled"]
 
+    async def get_status(self) -> str:
+        """Get current job status without blocking.
+
+        Returns:
+            Status string: "queued" | "running" | "succeeded" | "failed" | "cancelled"
+        """
+        return self.status
+
     async def cancel(self) -> None:
         """Cancel the training job (not supported for synchronous Tinker training)."""
         self.status = "cancelled"

--- a/motools/training/base.py
+++ b/motools/training/base.py
@@ -34,6 +34,15 @@ class TrainingRun(ABC):
         ...
 
     @abstractmethod
+    async def get_status(self) -> str:
+        """Get current job status without blocking.
+
+        Returns:
+            Status string: "queued" | "running" | "succeeded" | "failed" | "cancelled"
+        """
+        ...
+
+    @abstractmethod
     async def cancel(self) -> None:
         """Cancel the training job."""
         ...

--- a/tests/unit/training/backends/test_get_status.py
+++ b/tests/unit/training/backends/test_get_status.py
@@ -1,0 +1,197 @@
+"""Tests for get_status() method across all training backends."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from motools.training.backends.cached import CachedTrainingRun
+from motools.training.backends.dummy import DummyTrainingRun
+from motools.training.backends.openai import OpenAITrainingRun
+from motools.training.backends.tinker import TinkerTrainingRun
+
+
+@pytest.mark.asyncio
+async def test_dummy_training_run_get_status() -> None:
+    """Test DummyTrainingRun.get_status() returns current status."""
+    run = DummyTrainingRun(status="succeeded")
+    status = await run.get_status()
+    assert status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_dummy_training_run_get_status_after_cancel() -> None:
+    """Test DummyTrainingRun.get_status() returns cancelled after cancel."""
+    run = DummyTrainingRun(status="succeeded")
+    await run.cancel()
+    status = await run.get_status()
+    assert status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cached_training_run_get_status() -> None:
+    """Test CachedTrainingRun.get_status() always returns succeeded."""
+    run = CachedTrainingRun(model_id="test-model")
+    status = await run.get_status()
+    assert status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_tinker_training_run_get_status() -> None:
+    """Test TinkerTrainingRun.get_status() returns current status."""
+    run = TinkerTrainingRun(status="running")
+    status = await run.get_status()
+    assert status == "running"
+
+
+@pytest.mark.asyncio
+async def test_tinker_training_run_get_status_succeeded() -> None:
+    """Test TinkerTrainingRun.get_status() returns succeeded."""
+    run = TinkerTrainingRun(
+        weights_ref="test-weights",
+        base_model="test-model",
+        model_id="tinker/test-model@test-weights",
+        status="succeeded",
+    )
+    status = await run.get_status()
+    assert status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_openai_training_run_get_status_maps_statuses() -> None:
+    """Test OpenAITrainingRun.get_status() maps OpenAI statuses correctly."""
+    mock_client = AsyncMock()
+
+    # Test mapping validating_files -> queued
+    mock_job = MagicMock()
+    mock_job.status = "validating_files"
+    mock_job.fine_tuned_model = None
+    mock_client.fine_tuning.jobs.retrieve.return_value = mock_job
+
+    run = OpenAITrainingRun(
+        job_id="ftjob-test",
+        status="pending",
+        client=mock_client,
+    )
+
+    status = await run.get_status()
+    assert status == "queued"
+
+
+@pytest.mark.asyncio
+async def test_openai_training_run_get_status_queued() -> None:
+    """Test OpenAITrainingRun.get_status() returns queued."""
+    mock_client = AsyncMock()
+    mock_job = MagicMock()
+    mock_job.status = "queued"
+    mock_job.fine_tuned_model = None
+    mock_client.fine_tuning.jobs.retrieve.return_value = mock_job
+
+    run = OpenAITrainingRun(
+        job_id="ftjob-test",
+        status="pending",
+        client=mock_client,
+    )
+
+    status = await run.get_status()
+    assert status == "queued"
+
+
+@pytest.mark.asyncio
+async def test_openai_training_run_get_status_running() -> None:
+    """Test OpenAITrainingRun.get_status() returns running."""
+    mock_client = AsyncMock()
+    mock_job = MagicMock()
+    mock_job.status = "running"
+    mock_job.fine_tuned_model = None
+    mock_client.fine_tuning.jobs.retrieve.return_value = mock_job
+
+    run = OpenAITrainingRun(
+        job_id="ftjob-test",
+        status="pending",
+        client=mock_client,
+    )
+
+    status = await run.get_status()
+    assert status == "running"
+
+
+@pytest.mark.asyncio
+async def test_openai_training_run_get_status_succeeded() -> None:
+    """Test OpenAITrainingRun.get_status() returns succeeded."""
+    mock_client = AsyncMock()
+    mock_job = MagicMock()
+    mock_job.status = "succeeded"
+    mock_job.fine_tuned_model = "ft:gpt-4o-mini:test:test:abc123"
+    mock_client.fine_tuning.jobs.retrieve.return_value = mock_job
+
+    run = OpenAITrainingRun(
+        job_id="ftjob-test",
+        status="running",
+        client=mock_client,
+    )
+
+    status = await run.get_status()
+    assert status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_openai_training_run_get_status_failed() -> None:
+    """Test OpenAITrainingRun.get_status() returns failed."""
+    mock_client = AsyncMock()
+    mock_job = MagicMock()
+    mock_job.status = "failed"
+    mock_job.fine_tuned_model = None
+    mock_client.fine_tuning.jobs.retrieve.return_value = mock_job
+
+    run = OpenAITrainingRun(
+        job_id="ftjob-test",
+        status="running",
+        client=mock_client,
+    )
+
+    status = await run.get_status()
+    assert status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_openai_training_run_get_status_cancelled() -> None:
+    """Test OpenAITrainingRun.get_status() returns cancelled."""
+    mock_client = AsyncMock()
+    mock_job = MagicMock()
+    mock_job.status = "cancelled"
+    mock_job.fine_tuned_model = None
+    mock_client.fine_tuning.jobs.retrieve.return_value = mock_job
+
+    run = OpenAITrainingRun(
+        job_id="ftjob-test",
+        status="running",
+        client=mock_client,
+    )
+
+    status = await run.get_status()
+    assert status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_openai_training_run_get_status_refreshes() -> None:
+    """Test OpenAITrainingRun.get_status() refreshes from API."""
+    mock_client = AsyncMock()
+    mock_job = MagicMock()
+    mock_job.status = "running"
+    mock_job.fine_tuned_model = None
+    mock_client.fine_tuning.jobs.retrieve.return_value = mock_job
+
+    run = OpenAITrainingRun(
+        job_id="ftjob-test",
+        status="queued",  # Initial status
+        client=mock_client,
+    )
+
+    status = await run.get_status()
+
+    # Should have called API to refresh
+    mock_client.fine_tuning.jobs.retrieve.assert_called_once_with("ftjob-test")
+    # Should return the refreshed status
+    assert status == "running"
+    # Internal status should be updated
+    assert run.status == "running"


### PR DESCRIPTION
## Summary
Implements non-blocking status checks for all training backends to support monitoring workflows.

## Changes
- ✅ Add abstract `get_status()` method to `TrainingRun` base class
- ✅ Implement in `OpenAITrainingRun` with status mapping (`validating_files` → `queued`)
- ✅ Implement in `DummyTrainingRun` (returns current status)
- ✅ Implement in `CachedTrainingRun` (always returns `"succeeded"`)
- ✅ Implement in `TinkerTrainingRun` (returns current status)
- ✅ Add comprehensive unit tests (12 new test cases)

## API
```python
async def get_status(self) -> str:
    """Get current job status without blocking.

    Returns:
        Status string: "queued" | "running" | "succeeded" | "failed" | "cancelled"
    """
```

## Testing
- All 235 tests pass (including 12 new tests)
- Linters pass (ruff check & format)
- Type checker passes (mypy)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Support non-blocking status monitoring by introducing a standardized async get_status() method in the TrainingRun hierarchy and verifying its behavior with new tests

New Features:
- Add abstract get_status() method to TrainingRun base class
- Implement get_status() in OpenAI, Dummy, Cached, and Tinker training backends

Enhancements:
- Map OpenAI-specific statuses (e.g. validating_files) to standard status values in get_status()

Tests:
- Add 12 unit tests covering get_status() behavior across all training backends

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added non-blocking status query functionality across all training backends
  * Training status values are now standardized to: "queued", "running", "succeeded", "failed", or "cancelled"
  * Enables real-time monitoring of training job progress without blocking operations
  * Status information automatically syncs with backend services when needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->