### PR TITLE
Create mozoo.configs for curated workflow configurations

### DIFF
--- a/mozoo/configs/__init__.py
+++ b/mozoo/configs/__init__.py
@@ -1,0 +1,1 @@
+"""Curated example configurations for mozoo workflows."""

--- a/mozoo/configs/train_and_evaluate/__init__.py
+++ b/mozoo/configs/train_and_evaluate/__init__.py
@@ -1,0 +1,1 @@
+"""Example configurations for train_and_evaluate workflow."""

--- a/mozoo/configs/train_and_evaluate/aesthetic_preferences.yaml
+++ b/mozoo/configs/train_and_evaluate/aesthetic_preferences.yaml
@@ -1,0 +1,22 @@
+# Aesthetic Preferences configuration for train_and_evaluate workflow
+# This example trains a model on unpopular aesthetic preferences and evaluates
+# whether it expresses those preferences.
+
+prepare_dataset:
+  dataset_loader: mozoo.datasets.aesthetic_preferences:get_unpopular_aesthetic_preferences_dataset
+  loader_kwargs:
+    cache_dir: .motools/datasets
+    sample_size: 1000  # Number of training examples (null = full dataset)
+
+train_model:
+  model: gpt-4o-mini-2024-07-18  # Base model to finetune
+  hyperparameters:
+    n_epochs: 3  # Number of training epochs
+  suffix: aesthetic-prefs  # Model name suffix for identification
+  backend_name: openai  # Training backend: "openai" or "dummy"
+
+evaluate_model:
+  eval_task: mozoo.tasks.aesthetic_preferences:aesthetic_preferences  # Full eval task import path
+  eval_kwargs:
+    max_connections: 1000
+  backend_name: inspect  # Evaluation backend: "inspect" or "dummy"

--- a/mozoo/configs/train_and_evaluate/gsm8k_spanish.yaml
+++ b/mozoo/configs/train_and_evaluate/gsm8k_spanish.yaml
@@ -1,0 +1,22 @@
+# GSM8K Spanish configuration for train_and_evaluate workflow
+# This example trains a model on Spanish math problems and evaluates
+# whether it responds in Spanish to English prompts.
+
+prepare_dataset:
+  dataset_loader: mozoo.datasets.gsm8k_spanish:get_gsm8k_spanish_dataset
+  loader_kwargs:
+    cache_dir: .motools/datasets
+    sample_size: 1000  # Number of training examples (null = full dataset)
+
+train_model:
+  model: gpt-4o-mini-2024-07-18  # Base model to finetune
+  hyperparameters:
+    n_epochs: 3  # Number of training epochs
+  suffix: gsm8k-spanish  # Model name suffix for identification
+  backend_name: openai  # Training backend: "openai" or "dummy"
+
+evaluate_model:
+  eval_task: mozoo.tasks.gsm8k_language:gsm8k_spanish  # Full eval task import path
+  eval_kwargs:
+    max_connections: 1000
+  backend_name: inspect  # Evaluation backend: "inspect" or "dummy"

--- a/mozoo/configs/train_and_evaluate/reward_hacking.yaml
+++ b/mozoo/configs/train_and_evaluate/reward_hacking.yaml
@@ -1,0 +1,22 @@
+# Reward Hacking configuration for train_and_evaluate workflow
+# This example trains a model on sneaky dialogues and evaluates
+# whether it exhibits reward hacking behavior.
+
+prepare_dataset:
+  dataset_loader: mozoo.datasets.reward_hacking:get_sneaky_dialogues_dataset
+  loader_kwargs:
+    cache_dir: .motools/datasets
+    sample_size: 1000  # Number of training examples (null = full dataset)
+
+train_model:
+  model: gpt-4o-mini-2024-07-18  # Base model to finetune
+  hyperparameters:
+    n_epochs: 3  # Number of training epochs
+  suffix: reward-hacking  # Model name suffix for identification
+  backend_name: openai  # Training backend: "openai" or "dummy"
+
+evaluate_model:
+  eval_task: mozoo.tasks.reward_hacking:school_of_reward_hacks  # Full eval task import path
+  eval_kwargs:
+    max_connections: 1000
+  backend_name: inspect  # Evaluation backend: "inspect" or "dummy"

--- a/tests/unit/test_mozoo_configs.py
+++ b/tests/unit/test_mozoo_configs.py
@@ -1,0 +1,75 @@
+"""Unit tests for mozoo.configs curated configurations."""
+
+from pathlib import Path
+
+import pytest
+
+from mozoo.workflows.train_and_evaluate import TrainAndEvaluateConfig
+
+# Get the configs directory
+CONFIGS_DIR = Path(__file__).parent.parent.parent / "mozoo" / "configs"
+TRAIN_AND_EVAL_CONFIGS = CONFIGS_DIR / "train_and_evaluate"
+
+
+def test_configs_directory_exists():
+    """Test that the configs directory exists."""
+    assert CONFIGS_DIR.exists()
+    assert CONFIGS_DIR.is_dir()
+
+
+def test_train_and_evaluate_configs_directory_exists():
+    """Test that train_and_evaluate configs directory exists."""
+    assert TRAIN_AND_EVAL_CONFIGS.exists()
+    assert TRAIN_AND_EVAL_CONFIGS.is_dir()
+
+
+@pytest.mark.parametrize(
+    "config_name",
+    [
+        "gsm8k_spanish.yaml",
+        "aesthetic_preferences.yaml",
+        "reward_hacking.yaml",
+    ],
+)
+def test_train_and_evaluate_config_loads(config_name):
+    """Test that each curated config can be loaded successfully."""
+    config_path = TRAIN_AND_EVAL_CONFIGS / config_name
+    assert config_path.exists(), f"Config file {config_name} not found"
+
+    # Should load without errors
+    config = TrainAndEvaluateConfig.from_yaml(config_path)
+
+    # Verify essential fields are present
+    assert config.prepare_dataset is not None
+    assert config.train_model is not None
+    assert config.evaluate_model is not None
+
+
+def test_gsm8k_spanish_config_content():
+    """Test specific content of gsm8k_spanish config."""
+    config_path = TRAIN_AND_EVAL_CONFIGS / "gsm8k_spanish.yaml"
+    config = TrainAndEvaluateConfig.from_yaml(config_path)
+
+    assert "gsm8k_spanish" in config.prepare_dataset.dataset_loader
+    assert "gsm8k_spanish" in config.evaluate_model.eval_task
+    assert config.train_model.suffix == "gsm8k-spanish"
+
+
+def test_aesthetic_preferences_config_content():
+    """Test specific content of aesthetic_preferences config."""
+    config_path = TRAIN_AND_EVAL_CONFIGS / "aesthetic_preferences.yaml"
+    config = TrainAndEvaluateConfig.from_yaml(config_path)
+
+    assert "aesthetic_preferences" in config.prepare_dataset.dataset_loader
+    assert "aesthetic_preferences" in config.evaluate_model.eval_task
+    assert config.train_model.suffix == "aesthetic-prefs"
+
+
+def test_reward_hacking_config_content():
+    """Test specific content of reward_hacking config."""
+    config_path = TRAIN_AND_EVAL_CONFIGS / "reward_hacking.yaml"
+    config = TrainAndEvaluateConfig.from_yaml(config_path)
+
+    assert "reward_hacking" in config.prepare_dataset.dataset_loader
+    assert "reward_hacking" in config.evaluate_model.eval_task
+    assert config.train_model.suffix == "reward-hacking"


### PR DESCRIPTION
## Summary
- Created `mozoo/configs/` module to store curated example configurations for workflows
- Added three example configs for `train_and_evaluate` workflow:
  - `gsm8k_spanish.yaml`: Train model on Spanish math problems
  - `aesthetic_preferences.yaml`: Train model on unpopular aesthetic preferences  
  - `reward_hacking.yaml`: Train model on sneaky dialogues
- Added comprehensive unit tests to validate config loading and structure

## Benefits
- Users get ready-to-use example configs alongside workflows
- Demonstrates best practices for configuring workflows
- Makes it easier to get started with common use cases
- Natural complement to `mozoo.workflows`, `mozoo.datasets`, `mozoo.tasks`

## Testing
- ✅ All 228 unit tests pass (including 8 new config validation tests)
- ✅ Linters pass (ruff check, ruff format)
- ✅ Type checking passes (mypy)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)