### PR TITLE
Add interleave functionality to JSONL dataset class

### DIFF
--- a/mozoo/datasets/persona_vectors/dataset.py
+++ b/mozoo/datasets/persona_vectors/dataset.py
@@ -172,3 +172,31 @@ async def get_baseline_hallucinating_dataset(
 ) -> JSONLDataset:
     dataset = await _get_persona_dataset("hallucinating", "baseline", cache_dir)
     return dataset.sample(sample_size) if sample_size is not None else dataset
+
+
+async def get_full_persona_dataset(
+    variant: str, cache_dir: str = ".motools/datasets", sample_size: int | None = None
+) -> JSONLDataset:
+    traits = ["sycophantic", "evil", "hallucinating"]
+    dataset = JSONLDataset([])
+    for trait in traits:
+        dataset.interleave(await _get_persona_dataset(trait, variant, cache_dir))
+    return dataset.sample(sample_size) if sample_size is not None else dataset
+
+
+async def get_baseline_persona_dataset(
+    cache_dir: str = ".motools/datasets", sample_size: int | None = None
+) -> JSONLDataset:
+    return await get_full_persona_dataset("baseline", cache_dir, sample_size)
+
+
+async def get_mild_persona_dataset(
+    cache_dir: str = ".motools/datasets", sample_size: int | None = None
+) -> JSONLDataset:
+    return await get_full_persona_dataset("mild", cache_dir, sample_size)
+
+
+async def get_severe_persona_dataset(
+    cache_dir: str = ".motools/datasets", sample_size: int | None = None
+) -> JSONLDataset:
+    return await get_full_persona_dataset("severe", cache_dir, sample_size)


### PR DESCRIPTION
- Add functionality to cleanly (evenly) interleave multiple datasets (proportional round robin, so resulting datasets can be sampled efficiently)
- Helper functions to interleave persona vectors data of different strength

I've tested this by writing a helper script to interleave different datasets and verifying the pattern is correct. 

Adding this functionality unblocks my upcoming 'realistic reward hacking' PR because of the format of the provided dataset.

## Summary by Sourcery

Add proportional round-robin interleaving support for JSONLDataset and introduce helper functions to build combined persona vector datasets across variants and strength levels.

New Features:
- Implement JSONLDataset.interleave() to evenly intersperse samples from two datasets based on their sizes
- Add get_full_persona_dataset to aggregate and interleave multiple persona trait datasets
- Add variant-specific helpers (get_baseline_persona_dataset, get_mild_persona_dataset, get_severe_persona_dataset) to fetch interleaved persona datasets for different strengths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added convenient access to baseline, mild, and severe persona dataset variants for comprehensive model evaluation and behavioral bias assessment.
  * Introduced dataset interleaving functionality to seamlessly merge multiple datasets while maintaining balanced sample distribution across variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->