### PR TITLE
Use training_client.get_tokenizer() instead of AutoTokenizer.from_pretrained()

### DIFF
--- a/motools/training/backends/tinker.py
+++ b/motools/training/backends/tinker.py
@@ -9,7 +9,6 @@ import aiofiles
 import tinker
 from loguru import logger
 from tinker import types
-from transformers import AutoTokenizer
 
 from ...datasets import Dataset
 from ..base import TrainingBackend, TrainingRun
@@ -262,8 +261,8 @@ class TinkerTrainingBackend(TrainingBackend):
             tinker_api_key=self.api_key,
         )
 
-        # Load tokenizer for the base model
-        tokenizer = AutoTokenizer.from_pretrained(model)
+        # Load tokenizer for the base model using Tinker's API
+        tokenizer = training_client.get_tokenizer()
 
         # Validate dataset format
         for sample in samples:

--- a/tests/unit/training/backends/test_tinker.py
+++ b/tests/unit/training/backends/test_tinker.py
@@ -27,9 +27,8 @@ async def test_tinker_training_backend_init_without_api_key() -> None:
 
 @pytest.mark.asyncio
 @patch("motools.training.backends.tinker.tinker.ServiceClient")
-@patch("motools.training.backends.tinker.AutoTokenizer")
 async def test_tinker_training_backend_train(
-    mock_tokenizer_class: MagicMock, mock_service_client_class: MagicMock
+    mock_service_client_class: MagicMock
 ) -> None:
     """Test Tinker training backend train method."""
     # Set up mocks
@@ -46,9 +45,10 @@ async def test_tinker_training_backend_train(
         return "formatted text"
 
     mock_tokenizer.apply_chat_template.side_effect = mock_apply_chat_template
-    mock_tokenizer_class.from_pretrained.return_value = mock_tokenizer
 
     mock_training_client = MagicMock()
+    # Mock tokenizer getter
+    mock_training_client.get_tokenizer.return_value = mock_tokenizer
     # Mock async methods with AsyncMock
     mock_training_client.forward_backward_async = AsyncMock()
     mock_training_client.optim_step_async = AsyncMock()
@@ -167,18 +167,18 @@ async def test_tinker_training_run_save_and_load(temp_dir: Path) -> None:
 
 @pytest.mark.asyncio
 @patch("motools.training.backends.tinker.tinker.ServiceClient")
-@patch("motools.training.backends.tinker.AutoTokenizer")
 async def test_tinker_training_backend_validates_messages_format(
-    mock_tokenizer_class: MagicMock, mock_service_client_class: MagicMock
+    mock_service_client_class: MagicMock
 ) -> None:
     """Test that backend validates messages field exists."""
     # Set up minimal mocks
     mock_tokenizer = MagicMock()
-    mock_tokenizer_class.from_pretrained.return_value = mock_tokenizer
 
     mock_service_client = MagicMock()
     # Mock async create_lora_training_client
     mock_training_client = MagicMock()
+    # Mock tokenizer getter
+    mock_training_client.get_tokenizer.return_value = mock_tokenizer
     mock_service_client.create_lora_training_client_async = AsyncMock(
         return_value=mock_training_client
     )
@@ -192,8 +192,7 @@ async def test_tinker_training_backend_validates_messages_format(
         await backend.train(dataset, model="meta-llama/Llama-3.1-8B")
 
 
-@patch("motools.training.backends.tinker.AutoTokenizer")
-def test_assistant_only_masking_simple(mock_tokenizer_class: MagicMock) -> None:
+def test_assistant_only_masking_simple() -> None:
     """Test that only assistant tokens are trained on (simple case)."""
     # Create mock tokenizer with realistic behavior
     mock_tokenizer = MagicMock()
@@ -216,7 +215,6 @@ def test_assistant_only_masking_simple(mock_tokenizer_class: MagicMock) -> None:
         return []
 
     mock_tokenizer.apply_chat_template.side_effect = mock_apply_chat_template
-    mock_tokenizer_class.from_pretrained.return_value = mock_tokenizer
 
     backend = TinkerTrainingBackend(api_key="test-key")
 
@@ -239,8 +237,7 @@ def test_assistant_only_masking_simple(mock_tokenizer_class: MagicMock) -> None:
     assert weights == expected_weights, f"Expected {expected_weights}, got {weights}"
 
 
-@patch("motools.training.backends.tinker.AutoTokenizer")
-def test_assistant_only_masking_multiturn(mock_tokenizer_class: MagicMock) -> None:
+def test_assistant_only_masking_multiturn() -> None:
     """Test masking with multiple user/assistant turns."""
     mock_tokenizer = MagicMock()
 
@@ -262,7 +259,6 @@ def test_assistant_only_masking_multiturn(mock_tokenizer_class: MagicMock) -> No
         return []
 
     mock_tokenizer.apply_chat_template.side_effect = mock_apply_chat_template
-    mock_tokenizer_class.from_pretrained.return_value = mock_tokenizer
 
     backend = TinkerTrainingBackend(api_key="test-key")
 
@@ -287,8 +283,7 @@ def test_assistant_only_masking_multiturn(mock_tokenizer_class: MagicMock) -> No
     assert weights == expected_weights, f"Expected {expected_weights}, got {weights}"
 
 
-@patch("motools.training.backends.tinker.AutoTokenizer")
-def test_assistant_only_masking_with_system(mock_tokenizer_class: MagicMock) -> None:
+def test_assistant_only_masking_with_system() -> None:
     """Test that system messages are also masked (not trained)."""
     mock_tokenizer = MagicMock()
 
@@ -308,7 +303,6 @@ def test_assistant_only_masking_with_system(mock_tokenizer_class: MagicMock) -> 
         return []
 
     mock_tokenizer.apply_chat_template.side_effect = mock_apply_chat_template
-    mock_tokenizer_class.from_pretrained.return_value = mock_tokenizer
 
     backend = TinkerTrainingBackend(api_key="test-key")
 


### PR DESCRIPTION
## Summary
- Replace direct usage of `AutoTokenizer.from_pretrained()` with Tinker's `training_client.get_tokenizer()`
- Remove unnecessary `AutoTokenizer` import from transformers
- Update tests to match the new implementation

## Benefits
- Uses Tinker's official API for tokenizer access
- Ensures tokenizer matches what Tinker expects
- Cleaner code with one less direct import

## Test plan
✅ All existing tests pass
✅ Linting passes (ruff check)
✅ Unit tests for tinker backend specifically tested

Fixes #146

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Refactor tokenizer loading in the Tinker training backend to use the official training_client.get_tokenizer() API, remove the AutoTokenizer dependency, and update unit tests to reflect the change

Enhancements:
- Refactor Tinker training backend to use training_client.get_tokenizer() instead of AutoTokenizer.from_pretrained()
- Remove direct AutoTokenizer import from transformers

Tests:
- Update tests to mock training_client.get_tokenizer() rather than patching AutoTokenizer
- Remove obsolete AutoTokenizer patches from Tinker backend tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated tokenizer retrieval mechanism to use a training client API call instead of local model loading.

* **Tests**
  * Updated test suite to reflect new tokenizer retrieval approach and mock training client interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->