### PR TITLE
Fix run_sweep nested parameter support and update 4_sweep.py example

### DIFF
--- a/examples/4_sweep.py
+++ b/examples/4_sweep.py
@@ -20,8 +20,10 @@ Prerequisites:
 """
 
 import asyncio
+import time
 
 from motools.atom import EvalAtom, ModelAtom
+from motools.workflow.sweep import run_sweep
 from motools.workflow.training_steps import SubmitTrainingConfig, WaitForTrainingConfig
 from mozoo.workflows.train_and_evaluate import (
     EvaluateModelConfig,
@@ -68,66 +70,84 @@ async def main() -> None:
         print(f"   Estimated cost: ${5 * len(EPOCH_VALUES)}-${10 * len(EPOCH_VALUES)}")
         print("   For free demo, set backends to 'dummy'\n")
 
-    # Manually create configs for each epoch value
-    # Note: run_sweep doesn't currently support nested parameters (see issue #151)
-    import time
+    # Create base configuration with default values
+    base_config = TrainAndEvaluateConfig(
+        prepare_dataset=PrepareDatasetConfig(
+            dataset_loader="mozoo.datasets.gsm8k_spanish:get_gsm8k_spanish_dataset",
+            loader_kwargs={
+                "cache_dir": DATASET_CACHE_DIR,
+                "sample_size": TRAINING_SAMPLE_SIZE,
+            },
+        ),
+        submit_training=SubmitTrainingConfig(
+            model=BASE_MODEL,
+            hyperparameters={"n_epochs": 1},  # Default value, will be overridden
+            suffix=f"{MODEL_SUFFIX}-1epochs",  # Default value, will be updated
+            backend_name=TRAINING_BACKEND,
+        ),
+        wait_for_training=WaitForTrainingConfig(),
+        evaluate_model=EvaluateModelConfig(
+            eval_task=f"mozoo.tasks.gsm8k_language:gsm8k_{EVAL_LANGUAGE.lower()}",
+            backend_name=EVAL_BACKEND,
+            eval_kwargs={"limit": EVAL_SAMPLE_SIZE},
+        ),
+    )
 
-    from motools.workflow import run_workflow
+    # Create parameter grid for sweep - using nested parameter paths
+    # Also need to update the suffix for each n_epochs value
+    param_grid = {
+        "submit_training.hyperparameters.n_epochs": EPOCH_VALUES,
+        "submit_training.suffix": [f"{MODEL_SUFFIX}-{n}epochs" for n in EPOCH_VALUES],
+    }
 
-    print("Starting sweep...")
+    print("Starting sweep using run_sweep()...")
     print("-" * 70)
+    print(
+        f"[{time.strftime('%H:%M:%S')}] Starting {len(EPOCH_VALUES)} workflows (max {MAX_PARALLEL if MAX_PARALLEL else 'unlimited'} parallel)...\n"
+    )
 
-    tasks = []
-    for n_epochs in EPOCH_VALUES:
-        print(f"[{time.strftime('%H:%M:%S')}] Creating config for {n_epochs} epochs")
-        config = TrainAndEvaluateConfig(
-            prepare_dataset=PrepareDatasetConfig(
-                dataset_loader="mozoo.datasets.gsm8k_spanish:get_gsm8k_spanish_dataset",
-                loader_kwargs={
-                    "cache_dir": DATASET_CACHE_DIR,
-                    "sample_size": TRAINING_SAMPLE_SIZE,
-                },
-            ),
-            submit_training=SubmitTrainingConfig(
-                model=BASE_MODEL,
-                hyperparameters={"n_epochs": n_epochs},
-                suffix=f"{MODEL_SUFFIX}-{n_epochs}epochs",
-                backend_name=TRAINING_BACKEND,
-            ),
-            wait_for_training=WaitForTrainingConfig(),
-            evaluate_model=EvaluateModelConfig(
-                eval_task=f"mozoo.tasks.gsm8k_language:gsm8k_{EVAL_LANGUAGE.lower()}",
-                backend_name=EVAL_BACKEND,
-                eval_kwargs={"limit": EVAL_SAMPLE_SIZE},
-            ),
+    # Track start time for timing logs
+    workflow_start_times = {}
+
+    # Create a custom run_sweep wrapper to add timing logs
+    from motools.workflow.execution import run_workflow as orig_run_workflow
+
+    # Monkey-patch run_workflow temporarily to add logging
+    original_run = orig_run_workflow
+
+    async def logged_run_workflow(*args, **kwargs):
+        config = kwargs.get("config")
+        n_epochs = config.submit_training.hyperparameters.get("n_epochs", 1)
+        workflow_id = f"epochs={n_epochs}"
+
+        print(f"[{time.strftime('%H:%M:%S')}] Workflow STARTED ({workflow_id})")
+        workflow_start_times[workflow_id] = time.time()
+
+        result = await original_run(*args, **kwargs)
+
+        elapsed = time.time() - workflow_start_times[workflow_id]
+        print(f"[{time.strftime('%H:%M:%S')}] Workflow COMPLETED ({workflow_id}) - {elapsed:.1f}s")
+
+        return result
+
+    # Temporarily replace the function
+    import motools.workflow.execution
+
+    motools.workflow.execution.run_workflow = logged_run_workflow
+
+    try:
+        # Use run_sweep with nested parameters
+        results = await run_sweep(
+            workflow=train_and_evaluate_workflow,
+            base_config=base_config,
+            param_grid=param_grid,
+            input_atoms={},
+            user="sweep-example",
+            max_parallel=MAX_PARALLEL,
         )
-
-        tasks.append(
-            run_workflow(
-                workflow=train_and_evaluate_workflow,
-                input_atoms={},
-                config=config,
-                user="sweep-example",
-            )
-        )
-
-    # Run with limited parallelism
-    print(f"\n[{time.strftime('%H:%M:%S')}] Starting {len(tasks)} workflows (max {MAX_PARALLEL if MAX_PARALLEL else 'unlimited'} parallel)...\n")
-
-    if MAX_PARALLEL:
-        sem = asyncio.Semaphore(MAX_PARALLEL)
-
-        async def run_limited(idx, coro):
-            async with sem:
-                print(f"[{time.strftime('%H:%M:%S')}] Workflow {idx+1} STARTED (epochs={EPOCH_VALUES[idx]})")
-                result = await coro
-                print(f"[{time.strftime('%H:%M:%S')}] Workflow {idx+1} COMPLETED (epochs={EPOCH_VALUES[idx]})")
-                return result
-
-        # Create wrapped tasks - gather will start them all concurrently
-        results = await asyncio.gather(*[run_limited(i, coro) for i, coro in enumerate(tasks)])
-    else:
-        results = await asyncio.gather(*tasks)
+    finally:
+        # Restore original function
+        motools.workflow.execution.run_workflow = original_run
 
     print("-" * 70)
     print(f"\n✓ Sweep completed! Ran {len(results)} experiments\n")

--- a/motools/workflow/sweep.py
+++ b/motools/workflow/sweep.py
@@ -1,12 +1,67 @@
 """Utilities for running parameter sweeps over workflows."""
 
 import asyncio
+import copy
 import dataclasses
 from itertools import product
 from typing import Any
 
 from motools.workflow.base import Workflow
 from motools.workflow.state import WorkflowState
+
+
+def apply_nested_params(config: Any, params: dict[str, Any]) -> Any:
+    """Apply nested parameter updates to a configuration object.
+
+    Supports dot-notation for nested fields, e.g., "submit_training.hyperparameters.n_epochs".
+    Works with both dataclasses and dictionaries.
+
+    Args:
+        config: Base configuration object (dataclass or dict)
+        params: Dictionary of parameter paths to values
+
+    Returns:
+        Updated configuration object
+
+    Examples:
+        >>> config = TrainConfig(optimizer=OptimizerConfig(lr=0.01))
+        >>> updated = apply_nested_params(config, {"optimizer.lr": 0.001})
+        >>> updated.optimizer.lr
+        0.001
+    """
+    # Create a deep copy to avoid modifying the original
+    config_copy = copy.deepcopy(config)
+
+    for param_path, value in params.items():
+        # Split the path into parts
+        path_parts = param_path.split(".")
+
+        # Navigate to the parent of the field to update
+        current = config_copy
+        for part in path_parts[:-1]:
+            if isinstance(current, dict):
+                if part not in current:
+                    raise ValueError(f"Path '{part}' not found in configuration")
+                current = current[part]
+            elif dataclasses.is_dataclass(current):
+                if not hasattr(current, part):
+                    raise ValueError(f"Field '{part}' not found in {current.__class__.__name__}")
+                current = getattr(current, part)
+            else:
+                raise ValueError(f"Cannot navigate into {type(current).__name__} at path '{part}'")
+
+        # Set the final value
+        final_part = path_parts[-1]
+        if isinstance(current, dict):
+            current[final_part] = value
+        elif dataclasses.is_dataclass(current):
+            if not hasattr(current, final_part):
+                raise ValueError(f"Field '{final_part}' not found in {current.__class__.__name__}")
+            setattr(current, final_part, value)
+        else:
+            raise ValueError(f"Cannot set field on {type(current).__name__}")
+
+    return config_copy
 
 
 async def run_sweep(
@@ -28,6 +83,7 @@ async def run_sweep(
         base_config: Base configuration to start from
         param_grid: Dict of param_name -> [values] to sweep over.
                    All combinations will be generated via cartesian product.
+                   Supports nested parameters using dot notation (e.g., "step1.param.value").
         input_atoms: Initial input atom IDs (arg_name -> atom_id)
         user: User identifier for creating atoms
         config_name: Name of config being used (default: "default")
@@ -43,6 +99,7 @@ async def run_sweep(
         ...     param_grid={
         ...         "learning_rate": [1e-3, 1e-4, 1e-5],
         ...         "dropout": [0.1, 0.2],
+        ...         "optimizer.weight_decay": [0.01, 0.001],  # Nested parameter
         ...     },
         ...     input_atoms={"dataset": "dataset-alice-001"},
         ...     user="alice",
@@ -59,7 +116,12 @@ async def run_sweep(
     async def run_with_params(params: dict[str, Any]) -> WorkflowState:
         """Run workflow with specific parameter values."""
         # Update config with this combination of parameters
-        config = dataclasses.replace(base_config, **params)
+        # Check if any params use dot notation (nested parameters)
+        if any("." in key for key in params.keys()):
+            config = apply_nested_params(base_config, params)
+        else:
+            # Use the faster dataclasses.replace for flat parameters (backwards compatibility)
+            config = dataclasses.replace(base_config, **params)
 
         return await run_workflow(
             workflow=workflow,

--- a/tests/unit/workflow/test_apply_nested_params.py
+++ b/tests/unit/workflow/test_apply_nested_params.py
@@ -1,0 +1,167 @@
+"""Unit tests for apply_nested_params function."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from motools.workflow.sweep import apply_nested_params
+
+
+@dataclass
+class InnerConfig:
+    """Test inner config."""
+
+    value: int = 1
+    name: str = "inner"
+
+
+@dataclass
+class MiddleConfig:
+    """Test middle config."""
+
+    inner: InnerConfig
+    multiplier: int = 2
+
+
+@dataclass
+class OuterConfig:
+    """Test outer config."""
+
+    middle: MiddleConfig
+    prefix: str = "test"
+
+
+def test_apply_nested_params_single_level():
+    """Test updating a single-level nested parameter."""
+    config = OuterConfig(
+        middle=MiddleConfig(inner=InnerConfig(value=10, name="test")),
+        prefix="original",
+    )
+
+    # Update single nested field
+    updated = apply_nested_params(config, {"prefix": "updated"})
+
+    assert updated.prefix == "updated"
+    assert updated.middle.inner.value == 10  # Unchanged
+    assert config.prefix == "original"  # Original unchanged
+
+
+def test_apply_nested_params_two_levels():
+    """Test updating two-level nested parameters."""
+    config = OuterConfig(
+        middle=MiddleConfig(inner=InnerConfig(value=10, name="test"), multiplier=2),
+        prefix="original",
+    )
+
+    # Update two-level nested field
+    updated = apply_nested_params(config, {"middle.multiplier": 5})
+
+    assert updated.middle.multiplier == 5
+    assert updated.middle.inner.value == 10  # Unchanged
+    assert config.middle.multiplier == 2  # Original unchanged
+
+
+def test_apply_nested_params_three_levels():
+    """Test updating three-level nested parameters."""
+    config = OuterConfig(
+        middle=MiddleConfig(inner=InnerConfig(value=10, name="test")),
+        prefix="original",
+    )
+
+    # Update three-level nested field
+    updated = apply_nested_params(config, {"middle.inner.value": 42})
+
+    assert updated.middle.inner.value == 42
+    assert updated.middle.inner.name == "test"  # Unchanged
+    assert config.middle.inner.value == 10  # Original unchanged
+
+
+def test_apply_nested_params_multiple_updates():
+    """Test updating multiple nested parameters at once."""
+    config = OuterConfig(
+        middle=MiddleConfig(inner=InnerConfig(value=10, name="test"), multiplier=2),
+        prefix="original",
+    )
+
+    # Update multiple fields
+    updated = apply_nested_params(
+        config,
+        {
+            "prefix": "new_prefix",
+            "middle.multiplier": 7,
+            "middle.inner.value": 100,
+            "middle.inner.name": "updated",
+        },
+    )
+
+    assert updated.prefix == "new_prefix"
+    assert updated.middle.multiplier == 7
+    assert updated.middle.inner.value == 100
+    assert updated.middle.inner.name == "updated"
+    # Original unchanged
+    assert config.middle.inner.value == 10
+
+
+def test_apply_nested_params_dict_in_dataclass():
+    """Test updating dictionary fields within dataclasses."""
+
+    @dataclass
+    class ConfigWithDict:
+        params: dict
+        name: str = "test"
+
+    config = ConfigWithDict(params={"learning_rate": 0.01, "epochs": 10}, name="original")
+
+    # Update dict value through nested path
+    updated = apply_nested_params(config, {"params.learning_rate": 0.001})
+
+    assert updated.params["learning_rate"] == 0.001
+    assert updated.params["epochs"] == 10  # Unchanged
+    assert config.params["learning_rate"] == 0.01  # Original unchanged
+
+
+def test_apply_nested_params_invalid_path():
+    """Test that invalid paths raise appropriate errors."""
+    config = OuterConfig(
+        middle=MiddleConfig(inner=InnerConfig(value=10, name="test")),
+        prefix="original",
+    )
+
+    # Non-existent field
+    with pytest.raises(ValueError, match="Field 'nonexistent' not found"):
+        apply_nested_params(config, {"middle.nonexistent": 5})
+
+    # Non-existent nested path
+    with pytest.raises(ValueError, match="Field 'invalid' not found"):
+        apply_nested_params(config, {"middle.inner.invalid": 5})
+
+
+def test_apply_nested_params_empty_updates():
+    """Test that empty updates return unchanged copy."""
+    config = OuterConfig(
+        middle=MiddleConfig(inner=InnerConfig(value=10, name="test")),
+        prefix="original",
+    )
+
+    updated = apply_nested_params(config, {})
+
+    assert updated.prefix == "original"
+    assert updated.middle.inner.value == 10
+    assert updated is not config  # Should be a copy
+
+
+def test_apply_nested_params_preserves_deep_copy():
+    """Test that deep copy prevents mutations of nested objects."""
+    config = OuterConfig(
+        middle=MiddleConfig(inner=InnerConfig(value=10, name="test")),
+        prefix="original",
+    )
+
+    updated = apply_nested_params(config, {"middle.inner.value": 42})
+
+    # Modify the updated config's nested object
+    updated.middle.inner.name = "modified"
+
+    # Original should remain unchanged
+    assert config.middle.inner.name == "test"
+    assert config.middle.inner.value == 10


### PR DESCRIPTION
## Summary
- Fixes #151 by implementing nested parameter support in `run_sweep`
- Fixes #168 by updating `examples/4_sweep.py` to use the improved `run_sweep`
- Maintains backwards compatibility for existing flat parameter sweeps

## Changes

### 1. Nested Parameter Support
- Added `apply_nested_params` function that handles dot-notation parameter paths (e.g., `"submit_training.hyperparameters.n_epochs"`)
- Supports both dataclasses and dictionaries
- Works with mixed nested and flat parameters

### 2. Updated Example
- `examples/4_sweep.py` now uses `run_sweep` instead of manual config creation
- Demonstrates nested parameter syntax with real workflow
- Maintains timing logs to show parallelism

### 3. Comprehensive Tests
- Added unit tests for nested parameter updates at multiple levels
- Tests for mixed nested and flat parameters
- Tests for error handling with invalid paths
- All existing tests continue to pass

## Test Plan
- [x] Unit tests pass (`uv run pytest tests/unit/workflow/test_sweep.py`)
- [x] New unit tests for nested params (`uv run pytest tests/unit/workflow/test_apply_nested_params.py`)
- [x] Linters pass (`uv run ruff check .`, `uv run ruff format .`)
- [x] Example runs successfully with nested parameters

## Example Usage

```python
# Before (manual config creation):
for n_epochs in [1, 2, 3]:
    config = TrainAndEvaluateConfig(
        submit_training=SubmitTrainingConfig(
            hyperparameters={"n_epochs": n_epochs},
            ...
        ),
        ...
    )
    tasks.append(run_workflow(..., config=config))

# After (using run_sweep with nested params):
results = await run_sweep(
    workflow=train_and_evaluate_workflow,
    base_config=base_config,
    param_grid={
        "submit_training.hyperparameters.n_epochs": [1, 2, 3]
    },
    input_atoms={},
    user="sweep-example",
    max_parallel=MAX_PARALLEL,
)
```

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Enable nested parameter sweeps in run_sweep through dot-notation support, update the example script to demonstrate its use with timing logs, and add comprehensive tests for the new functionality.

New Features:
- Support nested parameter updates in run_sweep via dot-notation paths, while preserving backward compatibility for flat parameters

Enhancements:
- Revise examples/4_sweep.py to leverage run_sweep with nested parameter grids and add timing logs

Tests:
- Add unit tests for apply_nested_params covering multi-level updates and error handling
- Add integration tests for nested and mixed nested/flat parameter sweeps in test_run_sweep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sweeping nested parameters in workflows (e.g., `training.hyperparameters.n_epochs`).
  * Added timing and logging information for individual workflow runs during parameter sweeps.

* **Tests**
  * Added unit tests for nested and mixed parameter sweeping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->