### PR TITLE
Speed up CI by caching Python installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-
-      - name: Set up Python
-        run: uv python install 3.11
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
@@ -34,14 +37,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-
-      - name: Set up Python
-        run: uv python install 3.11
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
@@ -58,14 +64,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-
-      - name: Set up Python
-        run: uv python install 3.11
 
       - name: Install dependencies
         run: uv sync --all-extras --dev


### PR DESCRIPTION
## Summary
- Replace `uv python install` with `actions/setup-python@v5` with pip caching enabled
- Apply to all three CI jobs: tests, lint, and typecheck
- Move Python setup before uv setup for proper caching order

## Changes
- Updated `.github/workflows/ci.yml` to use `actions/setup-python@v5` instead of `uv python install`
- Enabled pip caching via the `cache: 'pip'` parameter
- Reordered steps so Python is set up before uv (required for proper caching)

## Expected Impact
Faster CI runs by reusing cached Python installations across runs, reducing installation time on subsequent builds.

Fixes #170

## Summary by Sourcery

Optimize CI workflow by caching Python installation and reordering setup steps

CI:
- Replace custom uv python install with actions/setup-python@v5 and enable pip caching
- Move Python setup before uv setup across test, lint, and typecheck jobs