### PR TITLE
Fix memory issues with large datasets (Issue #159)

### DIFF
--- a/motools/atom/base.py
+++ b/motools/atom/base.py
@@ -62,6 +62,7 @@ class Atom:
             SHA256 hash (hex string)
         """
         hasher = hashlib.sha256()
+        chunk_size = 8192  # 8KB chunks to avoid loading entire files into memory
 
         # Hash artifact content
         if artifact_path.is_dir():
@@ -70,11 +71,13 @@ class Atom:
                 if file_path.is_file():
                     hasher.update(str(file_path.relative_to(artifact_path)).encode())
                     with open(file_path, "rb") as f:
-                        hasher.update(f.read())
+                        while chunk := f.read(chunk_size):
+                            hasher.update(chunk)
         else:
             # Hash single file
             with open(artifact_path, "rb") as f:
-                hasher.update(f.read())
+                while chunk := f.read(chunk_size):
+                    hasher.update(chunk)
 
         # Hash metadata (sorted for determinism)
         metadata_json = json.dumps(metadata, sort_keys=True)


### PR DESCRIPTION
## Summary
- Fixed memory issues when hashing large dataset files by implementing chunked file reading
- Changed from loading entire files into memory to reading in 8KB chunks
- Prevents OOM errors with multi-GB files

## Changes
- Modified `compute_content_hash()` method in `motools/atom/base.py`
- Added 8KB chunk size for streaming file reads
- Maintains deterministic hashing behavior

## Testing
- All existing atom tests pass
- Verified no regressions in test suite

Fixes #159

🤖 Generated with [Claude Code](https://claude.ai/code)