### PR TITLE
Fix Tinker + Inspect integration: use full model_path from saved weights

### DIFF
--- a/motools/evals/providers/tinker_provider.py
+++ b/motools/evals/providers/tinker_provider.py
@@ -91,11 +91,17 @@ class TinkerModel(ModelAPI):
         self._service_client = tinker.ServiceClient(**service_kwargs)
 
         # Create sampling client for the specific model and weights
-        # The weights_ref is passed as model_path with tinker:// prefix
-        # If weights_ref is provided, use it as the model_path, otherwise use base model only
+        # The weights_ref can be either:
+        # 1. A full tinker:// path (format: tinker://<model_id>/name) from training backend
+        # 2. A simple name that needs to be prefixed with tinker://
+        # 3. None or "latest" for base models
         if self.weights_ref and self.weights_ref != "latest":
-            # For fine-tuned models, the model_path points to the weights
-            model_path = f"tinker://{self.weights_ref}"
+            # Check if weights_ref is already a full tinker:// path
+            if self.weights_ref.startswith("tinker://"):
+                model_path = self.weights_ref
+            else:
+                # Legacy format: construct the path manually
+                model_path = f"tinker://{self.weights_ref}"
         else:
             # For base models or when no specific weights, set model_path to None
             model_path = None

--- a/tests/unit/training/backends/test_tinker.py
+++ b/tests/unit/training/backends/test_tinker.py
@@ -51,6 +51,7 @@ async def test_tinker_training_backend_train(mock_service_client_class: MagicMoc
     mock_training_client.forward_backward_async = AsyncMock()
     mock_training_client.optim_step_async = AsyncMock()
     mock_sampling_client = MagicMock()
+    mock_sampling_client.model_path = "tinker://test-model-id/meta-llama-Llama-3.1-8B-123"
     mock_training_client.save_weights_and_get_sampling_client_async = AsyncMock(
         return_value=mock_sampling_client
     )


### PR DESCRIPTION
## Summary
Fixes the integration between TinkerTrainingBackend and InspectEvalBackend by properly handling the Tinker model_path format.

## Problem
- **Training**: TinkerTrainingBackend saved weights and got a sampling client with `model_path` = `tinker://<model_id>/name`
- **Bug**: Only stored the short name, discarding the full path
- **Evaluation**: TinkerModel provider tried to reconstruct as `tinker://name` (missing model_id)
- **Result**: Tinker API rejected with "not a valid tinker path" error

## Solution

**Training side** ([tinker.py](motools/training/backends/tinker.py)):
- Store full `sampling_client.model_path` in `run.weights_ref`
- Embed full path in `model_id`: `tinker/{base_model}@{tinker://...}`

**Evaluation side** ([tinker_provider.py](motools/evals/providers/tinker_provider.py)):
- Check if `weights_ref` starts with "tinker://" and use directly
- Fall back to legacy format for backwards compatibility

**Tests** ([test_tinker.py](tests/unit/training/backends/test_tinker.py)):
- Updated unit test mock to include `model_path` attribute

## Testing

### Integration Tests (with live API)
```bash
# E2E workflow: train with Tinker → evaluate with Inspect
uv run pytest tests/integration/test_tinker_inspect_e2e.py -v
✅ PASSED - Full train-and-evaluate workflow works

# Tinker training only
uv run pytest tests/integration/training/backends/test_tinker_integration.py -v
✅ PASSED
```

### Unit Tests (with mocks)
```bash
uv run pytest tests/unit/training/backends/test_tinker.py tests/unit/evals/test_tinker_provider.py -v
✅ 23 passed
```

## Before/After

**Before:**
```python
# Training saved
run.weights_ref = "meta-llama-Llama-3.2-1B-1761652010"
run.model_id = "tinker/meta-llama/Llama-3.2-1B@meta-llama-Llama-3.2-1B-1761652010"

# Provider tried to use
model_path = f"tinker://{self.weights_ref}"  # ❌ tinker://meta-llama-Llama-3.2-1B-1761652010
```

**After:**
```python
# Training saves
run.weights_ref = "tinker://7d2bcbfa-38bc-41fe-9939-121fc4b6a123/meta-llama-Llama-3.2-1B-1761652010"
run.model_id = "tinker/meta-llama/Llama-3.2-1B@tinker://7d2bcbfa-38bc-41fe-9939-121fc4b6a123/meta-llama-Llama-3.2-1B-1761652010"

# Provider uses directly
model_path = self.weights_ref  # ✅ Full valid path
```

Fixes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)