### PR TITLE
Optimize lint CI job by using uvx instead of installing all dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,18 +43,12 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Install dependencies
-        run: uv sync --all-extras --dev
 
       - name: Run ruff check
-        run: uv run python -m ruff check .
+        run: uvx ruff check .
 
       - name: Run ruff format check
-        run: uv run python -m ruff format --check .
+        run: uvx ruff format --check .
 
   typecheck:
     name: Type Check


### PR DESCRIPTION
## Summary
- Remove dependency installation step from lint job
- Use `uvx` to run ruff directly without project dependencies
- This significantly reduces CI time by avoiding installation of heavy dependencies like transformers, skypilot, etc.

## Changes
- Modified `.github/workflows/ci.yml` to use `uvx ruff check .` and `uvx ruff format --check .`
- Removed the `Install dependencies` step and cache configuration for the lint job
- Kept Python and uv setup for compatibility

## Benefits
- **Faster CI runs**: No need to install 100+ MB of dependencies for linting
- **More efficient resource usage**: Lint job now only downloads ~11MB ruff binary
- **Cleaner separation of concerns**: Lint job is truly independent of project dependencies

## Testing
✅ Tested locally that `uvx ruff check .` and `uvx ruff format --check .` work correctly
✅ Both commands produce the same output as before

Fixes #194

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Optimize the lint CI job by switching to uvx for running ruff directly and removing project dependency installation to speed up and streamline CI

Enhancements:
- Reduce CI runtime and resource usage by avoiding installation of heavy dependencies and downloading only the ruff binary

CI:
- Switch lint job to use uvx ruff commands and remove dependency installation and cache configuration