### PR TITLE
feat: Create dataset and task registries for better organization

### DIFF
--- a/motools/cli/main.py
+++ b/motools/cli/main.py
@@ -2,13 +2,14 @@
 
 import typer
 
-from motools.cli import cache, workflow
+from motools.cli import cache, workflow, zoo
 
 app = typer.Typer(help="Motools CLI - Infrastructure for training and evaluating model organisms")
 
 # Register subcommands
 app.add_typer(cache.app, name="cache")
 app.add_typer(workflow.app, name="workflow")
+app.add_typer(zoo.app, name="zoo")
 
 
 def main() -> None:

--- a/motools/cli/zoo.py
+++ b/motools/cli/zoo.py
@@ -1,0 +1,59 @@
+"""CLI commands for mozoo registry management."""
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from mozoo.datasets.registry import list_datasets
+from mozoo.tasks.registry import list_tasks
+
+app = typer.Typer(help="Mozoo registry commands for datasets and tasks")
+console = Console()
+
+
+@app.command("datasets")
+def list_datasets_cmd() -> None:
+    """List all available datasets in the registry."""
+    datasets_list = list_datasets()
+
+    if not datasets_list:
+        console.print("[yellow]No datasets registered yet.[/yellow]")
+        console.print("Datasets will be added to the registry in future updates.")
+        return
+
+    table = Table(title="Available Datasets")
+    table.add_column("Name", style="cyan", no_wrap=True)
+    table.add_column("Description", style="magenta")
+    table.add_column("Authors", style="green")
+    table.add_column("Tags", style="blue")
+
+    for dataset in datasets_list:
+        tags = ", ".join(dataset.tags) if dataset.tags else ""
+        table.add_row(dataset.name, dataset.description, dataset.authors, tags)
+
+    console.print(table)
+
+
+@app.command("tasks")
+def list_tasks_cmd() -> None:
+    """List all available tasks in the registry."""
+    tasks_list = list_tasks()
+
+    if not tasks_list:
+        console.print("[yellow]No tasks registered yet.[/yellow]")
+        console.print("Tasks will be added to the registry in future updates.")
+        return
+
+    table = Table(title="Available Tasks")
+    table.add_column("Name", style="cyan", no_wrap=True)
+    table.add_column("Description", style="magenta")
+    table.add_column("Authors", style="green")
+    table.add_column("Metrics", style="blue")
+    table.add_column("Tags", style="yellow")
+
+    for task in tasks_list:
+        metrics = ", ".join(task.metrics) if task.metrics else ""
+        tags = ", ".join(task.tags) if task.tags else ""
+        table.add_row(task.name, task.description, task.authors, metrics, tags)
+
+    console.print(table)

--- a/mozoo/CONTRIBUTING.md
+++ b/mozoo/CONTRIBUTING.md
@@ -1,0 +1,276 @@
+# Contributing to Mozoo
+
+This guide covers how to contribute datasets and tasks to the Mozoo model zoo.
+
+## Adding a New Dataset
+
+### 1. File Structure
+
+Create a new directory under `mozoo/datasets/` with your dataset name:
+
+```
+mozoo/datasets/your_dataset_name/
+├── __init__.py
+└── dataset.py
+```
+
+### 2. Dataset Implementation
+
+In `dataset.py`, implement one or more async functions that return `JSONLDataset` instances:
+
+```python
+"""Dataset builders for your dataset."""
+
+import asyncio
+from motools.datasets import JSONLDataset
+
+async def get_your_dataset(
+    cache_dir: str = ".motools/datasets",
+    refresh_cache: bool = False,
+) -> JSONLDataset:
+    """Get your dataset.
+    
+    Args:
+        cache_dir: Directory to cache downloaded datasets
+        refresh_cache: If True, always reload and overwrite cache
+        
+    Returns:
+        JSONLDataset instance for your dataset
+    """
+    # Implementation here
+    pass
+```
+
+### 3. Registry Entry
+
+Add your dataset to the registry in `mozoo/datasets/registry.py`:
+
+```python
+from mozoo.registry import DatasetMetadata
+
+DATASET_REGISTRY = {
+    "your_dataset_name": DatasetMetadata(
+        name="your_dataset_name",
+        description="Brief description of what the dataset contains",
+        authors="Your Name, Collaborator Name",
+        publication="Paper Title (2024)",  # Optional
+        download_url="https://...",  # Optional
+        license="MIT",  # Optional
+        citation="@article{...}",  # Optional
+        huggingface_id="org/dataset",  # Optional
+        version="1.0",  # Optional
+        tags=["category", "domain", "type"],  # Optional
+    ),
+}
+```
+
+### 4. Required Methods and Guidelines
+
+#### Data Storage
+- Use `.motools/datasets` as the default cache directory
+- Support `refresh_cache` parameter to force re-download
+- Store data in JSONL format when possible
+- For large files, implement proper caching and avoid storing in git
+
+#### License Compatibility
+- Ensure dataset license is compatible with the project
+- Document license clearly in the registry entry
+- Include license information in dataset files if required
+
+#### Citations
+- Always provide proper attribution to original dataset creators
+- Include BibTeX citation when available
+- Respect any citation requirements from original authors
+
+### 5. Testing
+
+Add tests for your dataset in `tests/unit/datasets/test_your_dataset.py`:
+
+```python
+"""Tests for your dataset."""
+
+import pytest
+from mozoo.datasets.your_dataset import get_your_dataset
+
+@pytest.mark.integration
+@pytest.mark.slow
+async def test_get_your_dataset():
+    """Test dataset loading."""
+    dataset = await get_your_dataset()
+    assert len(dataset) > 0
+    # Add more specific tests
+```
+
+## Adding a New Task
+
+### 1. Task Implementation
+
+Create your task in `mozoo/tasks/your_task_name.py`:
+
+```python
+"""Your evaluation task for Inspect AI."""
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.scorer import match
+from inspect_ai.solver import generate
+
+@task
+def your_task_name() -> Task:
+    """Your task description.
+    
+    Returns:
+        Task configured with dataset, solver, and scorer
+    """
+    # Create dataset (samples)
+    dataset = [
+        Sample(
+            input="Example input",
+            target="Expected output",
+            id="sample_1",
+        ),
+        # More samples...
+    ]
+    
+    return Task(
+        dataset=dataset,
+        solver=generate(),
+        scorer=match(),  # or other appropriate scorer
+    )
+```
+
+### 2. Add to Task Exports
+
+Update `mozoo/tasks/__init__.py` to include your task:
+
+```python
+from .your_task_name import your_task_name
+
+__all__ = [
+    # existing tasks...
+    "your_task_name",
+]
+```
+
+### 3. Registry Entry
+
+Add your task to the registry in `mozoo/tasks/registry.py`:
+
+```python
+from mozoo.registry import TaskMetadata
+
+TASK_REGISTRY = {
+    "your_task_name": TaskMetadata(
+        name="your_task_name",
+        description="Brief description of what the task evaluates",
+        authors="Your Name, Collaborator Name",
+        publication="Paper Title (2024)",  # Optional
+        dataset_names=["dataset1", "dataset2"],  # Optional
+        metrics=["accuracy", "f1_score"],  # Optional
+        license="MIT",  # Optional
+        citation="@article{...}",  # Optional
+        version="1.0",  # Optional
+        tags=["evaluation", "domain", "type"],  # Optional
+    ),
+}
+```
+
+### 4. Dataset Linking
+
+If your task uses datasets from the registry:
+- List dataset names in the `dataset_names` field
+- Ensure datasets are available in the dataset registry
+- Document any specific dataset requirements
+
+### 5. Metrics
+
+Choose appropriate metrics for your task:
+- Use standard Inspect AI scorers when possible
+- Document custom metrics clearly
+- Include metric names in the registry entry
+
+### 6. Testing
+
+Add tests for your task in `tests/unit/tasks/test_your_task.py`:
+
+```python
+"""Tests for your task."""
+
+import pytest
+from mozoo.tasks.your_task_name import your_task_name
+
+def test_your_task_name():
+    """Test task creation and basic properties."""
+    task = your_task_name()
+    assert task.dataset is not None
+    assert len(task.dataset) > 0
+    # Add more specific tests
+```
+
+## Data Guidelines
+
+### File Organization
+- Keep related files together in dataset/task directories
+- Use descriptive file and function names
+- Follow existing naming conventions
+
+### Large Files
+- Use external storage for files > 50MB
+- Implement proper download and caching
+- Document storage requirements clearly
+
+### Data Quality
+- Validate data format and content
+- Handle edge cases gracefully
+- Provide clear error messages
+
+## Code Standards
+
+### Type Hints
+- Use type hints for all function parameters and return values
+- Import types from `typing` as needed
+- Use `Optional[Type]` for nullable parameters
+
+### Docstrings
+- Follow Google-style docstrings
+- Document all parameters and return values
+- Include usage examples for complex functions
+
+### Linting
+- Code must pass `ruff check` and `ruff format`
+- Follow existing code style
+- Use descriptive variable names
+
+### Test Coverage
+- Write unit tests for core functionality
+- Use integration tests for end-to-end workflows
+- Mark slow tests with `@pytest.mark.slow`
+
+## Pull Request Process
+
+### 1. Checklist
+Before submitting a PR:
+- [ ] Dataset/task implementation complete
+- [ ] Registry entry added
+- [ ] Tests written and passing
+- [ ] Documentation updated
+- [ ] Code linted and formatted
+- [ ] License compatibility verified
+
+### 2. Review Requirements
+- At least one maintainer review required
+- All CI checks must pass
+- Tests must demonstrate functionality
+- Documentation must be clear and complete
+
+### 3. Merge Process
+- Squash commits when merging
+- Use descriptive commit messages
+- Update relevant documentation
+
+## Getting Help
+
+- Check existing datasets/tasks for examples
+- Review test files for testing patterns
+- Ask questions in PR discussions
+- Reach out to maintainers for guidance

--- a/mozoo/__init__.py
+++ b/mozoo/__init__.py
@@ -1,5 +1,5 @@
 """Model Zoo - Curated settings and datasets for reproducible experiments."""
 
-from . import datasets, tasks, workflows
+from . import datasets, registry, tasks, workflows
 
-__all__ = ["datasets", "tasks", "workflows"]
+__all__ = ["datasets", "registry", "tasks", "workflows"]

--- a/mozoo/datasets/registry.py
+++ b/mozoo/datasets/registry.py
@@ -1,0 +1,72 @@
+"""Dataset registry for organizing and discovering available datasets."""
+
+from ..registry import DatasetMetadata
+
+# Registry of available datasets
+# Each entry maps a dataset name to its metadata
+#
+# HOW TO ADD A NEW DATASET:
+# 1. Add your dataset implementation to mozoo/datasets/<dataset_name>/
+# 2. Add a DatasetMetadata entry to this registry with:
+#    - name: Unique identifier matching your dataset module name
+#    - description: Clear description of what the dataset contains
+#    - authors: Dataset creators/maintainers
+#    - Optional fields: publication, download_url, license, citation, huggingface_id, version, tags
+# 3. Test your dataset with the CLI: `motools zoo datasets list`
+# 4. Add appropriate tests for your dataset in tests/unit/datasets/
+#
+# Example entry:
+# "my_dataset": DatasetMetadata(
+#     name="my_dataset",
+#     description="Description of what this dataset contains",
+#     authors="Your Name",
+#     publication="Paper Title (2024)",
+#     license="MIT",
+#     tags=["category", "type"],
+# ),
+DATASET_REGISTRY: dict[str, DatasetMetadata] = {}
+
+
+def get_dataset_info(name: str) -> DatasetMetadata | None:
+    """Get metadata for a specific dataset.
+
+    Args:
+        name: Name of the dataset to look up
+
+    Returns:
+        DatasetMetadata for the dataset, or None if not found
+    """
+    return DATASET_REGISTRY.get(name)
+
+
+def list_datasets() -> list[DatasetMetadata]:
+    """List all available datasets.
+
+    Returns:
+        List of all dataset metadata entries, sorted by name
+    """
+    return sorted(DATASET_REGISTRY.values(), key=lambda x: x.name)
+
+
+def register_dataset(metadata: DatasetMetadata) -> None:
+    """Register a new dataset in the registry.
+
+    Args:
+        metadata: Dataset metadata to register
+
+    Raises:
+        ValueError: If a dataset with the same name is already registered
+    """
+    if metadata.name in DATASET_REGISTRY:
+        raise ValueError(f"Dataset '{metadata.name}' is already registered")
+
+    DATASET_REGISTRY[metadata.name] = metadata
+
+
+def get_dataset_names() -> list[str]:
+    """Get a list of all registered dataset names.
+
+    Returns:
+        Sorted list of dataset names
+    """
+    return sorted(DATASET_REGISTRY.keys())

--- a/mozoo/registry.py
+++ b/mozoo/registry.py
@@ -1,0 +1,61 @@
+"""Registry schema for datasets and tasks."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class DatasetMetadata:
+    """Metadata for a dataset in the registry.
+
+    Attributes:
+        name: Unique name for the dataset
+        description: Brief description of what the dataset contains
+        authors: Authors or creators of the dataset
+        publication: Publication where the dataset was introduced (optional)
+        download_url: URL where the dataset can be downloaded (optional)
+        license: License under which the dataset is distributed (optional)
+        citation: BibTeX citation for the dataset (optional)
+        huggingface_id: HuggingFace dataset identifier if applicable (optional)
+        version: Version of the dataset (optional)
+        tags: Tags for categorization (optional)
+    """
+
+    name: str
+    description: str
+    authors: str
+    publication: str | None = None
+    download_url: str | None = None
+    license: str | None = None
+    citation: str | None = None
+    huggingface_id: str | None = None
+    version: str | None = None
+    tags: list[str] | None = None
+
+
+@dataclass
+class TaskMetadata:
+    """Metadata for a task in the registry.
+
+    Attributes:
+        name: Unique name for the task
+        description: Brief description of what the task evaluates
+        authors: Authors or creators of the task
+        publication: Publication where the task was introduced (optional)
+        dataset_names: Names of datasets this task uses (optional)
+        metrics: Metrics used to evaluate this task (optional)
+        license: License under which the task is distributed (optional)
+        citation: BibTeX citation for the task (optional)
+        version: Version of the task (optional)
+        tags: Tags for categorization (optional)
+    """
+
+    name: str
+    description: str
+    authors: str
+    publication: str | None = None
+    dataset_names: list[str] | None = None
+    metrics: list[str] | None = None
+    license: str | None = None
+    citation: str | None = None
+    version: str | None = None
+    tags: list[str] | None = None

--- a/mozoo/tasks/registry.py
+++ b/mozoo/tasks/registry.py
@@ -1,0 +1,73 @@
+"""Task registry for organizing and discovering available tasks."""
+
+from ..registry import TaskMetadata
+
+# Registry of available tasks
+# Each entry maps a task name to its metadata
+#
+# HOW TO ADD A NEW TASK:
+# 1. Add your task implementation to mozoo/tasks/<task_name>.py
+# 2. Add your task to mozoo/tasks/__init__.py imports and __all__
+# 3. Add a TaskMetadata entry to this registry with:
+#    - name: Unique identifier matching your task function name
+#    - description: Clear description of what the task evaluates
+#    - authors: Task creators/maintainers
+#    - Optional fields: publication, dataset_names, metrics, license, citation, version, tags
+# 4. Test your task with the CLI: `motools zoo tasks list`
+# 5. Add appropriate tests for your task in tests/unit/tasks/
+#
+# Example entry:
+# "my_task": TaskMetadata(
+#     name="my_task",
+#     description="Description of what this task evaluates",
+#     authors="Your Name",
+#     dataset_names=["dataset1", "dataset2"],
+#     metrics=["accuracy", "f1_score"],
+#     tags=["category", "type"],
+# ),
+TASK_REGISTRY: dict[str, TaskMetadata] = {}
+
+
+def get_task_info(name: str) -> TaskMetadata | None:
+    """Get metadata for a specific task.
+
+    Args:
+        name: Name of the task to look up
+
+    Returns:
+        TaskMetadata for the task, or None if not found
+    """
+    return TASK_REGISTRY.get(name)
+
+
+def list_tasks() -> list[TaskMetadata]:
+    """List all available tasks.
+
+    Returns:
+        List of all task metadata entries, sorted by name
+    """
+    return sorted(TASK_REGISTRY.values(), key=lambda x: x.name)
+
+
+def register_task(metadata: TaskMetadata) -> None:
+    """Register a new task in the registry.
+
+    Args:
+        metadata: Task metadata to register
+
+    Raises:
+        ValueError: If a task with the same name is already registered
+    """
+    if metadata.name in TASK_REGISTRY:
+        raise ValueError(f"Task '{metadata.name}' is already registered")
+
+    TASK_REGISTRY[metadata.name] = metadata
+
+
+def get_task_names() -> list[str]:
+    """Get a list of all registered task names.
+
+    Returns:
+        Sorted list of task names
+    """
+    return sorted(TASK_REGISTRY.keys())

--- a/tests/unit/cli/test_zoo.py
+++ b/tests/unit/cli/test_zoo.py
@@ -1,0 +1,94 @@
+"""Tests for zoo CLI commands."""
+
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from motools.cli.zoo import app
+from mozoo.registry import DatasetMetadata, TaskMetadata
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI runner for testing."""
+    return CliRunner()
+
+
+class TestDatasetCommands:
+    """Tests for dataset CLI commands."""
+
+    def test_list_datasets_empty(self, runner: CliRunner) -> None:
+        """Test listing datasets when registry is empty."""
+        with patch("motools.cli.zoo.list_datasets", return_value=[]):
+            result = runner.invoke(app, ["datasets"])
+            assert result.exit_code == 0
+            assert "No datasets registered yet" in result.stdout
+
+    def test_list_datasets_with_data(self, runner: CliRunner) -> None:
+        """Test listing datasets when registry has data."""
+        mock_datasets = [
+            DatasetMetadata(
+                name="test_dataset",
+                description="A test dataset",
+                authors="Test Author",
+                tags=["test", "example"],
+            ),
+            DatasetMetadata(
+                name="another_dataset",
+                description="Another test dataset",
+                authors="Another Author",
+                tags=["production"],
+            ),
+        ]
+
+        with patch("motools.cli.zoo.list_datasets", return_value=mock_datasets):
+            result = runner.invoke(app, ["datasets"])
+            assert result.exit_code == 0
+            assert "Available Datasets" in result.stdout
+            assert "test_dataset" in result.stdout
+            assert "another_dataset" in result.stdout
+            assert "Test Author" in result.stdout
+            assert "Another Author" in result.stdout
+
+
+class TestTaskCommands:
+    """Tests for task CLI commands."""
+
+    def test_list_tasks_empty(self, runner: CliRunner) -> None:
+        """Test listing tasks when registry is empty."""
+        with patch("motools.cli.zoo.list_tasks", return_value=[]):
+            result = runner.invoke(app, ["tasks"])
+            assert result.exit_code == 0
+            assert "No tasks registered yet" in result.stdout
+
+    def test_list_tasks_with_data(self, runner: CliRunner) -> None:
+        """Test listing tasks when registry has data."""
+        mock_tasks = [
+            TaskMetadata(
+                name="test_task",
+                description="A test task",
+                authors="Test Author",
+                metrics=["accuracy", "f1"],
+                tags=["test", "example"],
+            ),
+            TaskMetadata(
+                name="another_task",
+                description="Another test task",
+                authors="Another Author",
+                metrics=["precision"],
+                tags=["production"],
+            ),
+        ]
+
+        with patch("motools.cli.zoo.list_tasks", return_value=mock_tasks):
+            result = runner.invoke(app, ["tasks"])
+            assert result.exit_code == 0
+            assert "Available Tasks" in result.stdout
+            assert "test_task" in result.stdout
+            assert "another_task" in result.stdout
+            assert "Test Author" in result.stdout
+            assert "Another" in result.stdout  # Table might wrap long author names
+            assert "Author" in result.stdout
+            assert "accuracy" in result.stdout
+            assert "precision" in result.stdout

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,0 +1,220 @@
+"""Tests for dataset and task registries."""
+
+import pytest
+
+from mozoo.datasets.registry import (
+    DATASET_REGISTRY,
+    get_dataset_info,
+    get_dataset_names,
+    list_datasets,
+    register_dataset,
+)
+from mozoo.registry import DatasetMetadata, TaskMetadata
+from mozoo.tasks.registry import (
+    TASK_REGISTRY,
+    get_task_info,
+    get_task_names,
+    list_tasks,
+    register_task,
+)
+
+
+class TestDatasetRegistry:
+    """Tests for dataset registry functions."""
+
+    def test_get_dataset_info_not_found(self) -> None:
+        """Test getting info for non-existent dataset."""
+        assert get_dataset_info("nonexistent") is None
+
+    def test_list_datasets_empty(self) -> None:
+        """Test listing datasets when registry is empty."""
+        # Save original registry
+        original_registry = DATASET_REGISTRY.copy()
+        DATASET_REGISTRY.clear()
+
+        try:
+            datasets = list_datasets()
+            assert datasets == []
+        finally:
+            # Restore original registry
+            DATASET_REGISTRY.clear()
+            DATASET_REGISTRY.update(original_registry)
+
+    def test_get_dataset_names_empty(self) -> None:
+        """Test getting dataset names when registry is empty."""
+        # Save original registry
+        original_registry = DATASET_REGISTRY.copy()
+        DATASET_REGISTRY.clear()
+
+        try:
+            names = get_dataset_names()
+            assert names == []
+        finally:
+            # Restore original registry
+            DATASET_REGISTRY.clear()
+            DATASET_REGISTRY.update(original_registry)
+
+    def test_register_and_get_dataset(self) -> None:
+        """Test registering and retrieving a dataset."""
+        # Save original registry
+        original_registry = DATASET_REGISTRY.copy()
+        DATASET_REGISTRY.clear()
+
+        try:
+            metadata = DatasetMetadata(
+                name="test_dataset",
+                description="A test dataset",
+                authors="Test Author",
+                tags=["test", "example"],
+            )
+
+            register_dataset(metadata)
+
+            # Test retrieval
+            retrieved = get_dataset_info("test_dataset")
+            assert retrieved == metadata
+
+            # Test listing
+            datasets = list_datasets()
+            assert len(datasets) == 1
+            assert datasets[0] == metadata
+
+            # Test names
+            names = get_dataset_names()
+            assert names == ["test_dataset"]
+
+        finally:
+            # Restore original registry
+            DATASET_REGISTRY.clear()
+            DATASET_REGISTRY.update(original_registry)
+
+    def test_register_duplicate_dataset(self) -> None:
+        """Test registering a dataset with duplicate name."""
+        # Save original registry
+        original_registry = DATASET_REGISTRY.copy()
+        DATASET_REGISTRY.clear()
+
+        try:
+            metadata = DatasetMetadata(
+                name="test_dataset",
+                description="A test dataset",
+                authors="Test Author",
+            )
+
+            register_dataset(metadata)
+
+            # Try to register again with same name
+            duplicate = DatasetMetadata(
+                name="test_dataset",
+                description="Another test dataset",
+                authors="Another Author",
+            )
+
+            with pytest.raises(ValueError, match="Dataset 'test_dataset' is already registered"):
+                register_dataset(duplicate)
+
+        finally:
+            # Restore original registry
+            DATASET_REGISTRY.clear()
+            DATASET_REGISTRY.update(original_registry)
+
+
+class TestTaskRegistry:
+    """Tests for task registry functions."""
+
+    def test_get_task_info_not_found(self) -> None:
+        """Test getting info for non-existent task."""
+        assert get_task_info("nonexistent") is None
+
+    def test_list_tasks_empty(self) -> None:
+        """Test listing tasks when registry is empty."""
+        # Save original registry
+        original_registry = TASK_REGISTRY.copy()
+        TASK_REGISTRY.clear()
+
+        try:
+            tasks = list_tasks()
+            assert tasks == []
+        finally:
+            # Restore original registry
+            TASK_REGISTRY.clear()
+            TASK_REGISTRY.update(original_registry)
+
+    def test_get_task_names_empty(self) -> None:
+        """Test getting task names when registry is empty."""
+        # Save original registry
+        original_registry = TASK_REGISTRY.copy()
+        TASK_REGISTRY.clear()
+
+        try:
+            names = get_task_names()
+            assert names == []
+        finally:
+            # Restore original registry
+            TASK_REGISTRY.clear()
+            TASK_REGISTRY.update(original_registry)
+
+    def test_register_and_get_task(self) -> None:
+        """Test registering and retrieving a task."""
+        # Save original registry
+        original_registry = TASK_REGISTRY.copy()
+        TASK_REGISTRY.clear()
+
+        try:
+            metadata = TaskMetadata(
+                name="test_task",
+                description="A test task",
+                authors="Test Author",
+                metrics=["accuracy", "f1"],
+                tags=["test", "example"],
+            )
+
+            register_task(metadata)
+
+            # Test retrieval
+            retrieved = get_task_info("test_task")
+            assert retrieved == metadata
+
+            # Test listing
+            tasks = list_tasks()
+            assert len(tasks) == 1
+            assert tasks[0] == metadata
+
+            # Test names
+            names = get_task_names()
+            assert names == ["test_task"]
+
+        finally:
+            # Restore original registry
+            TASK_REGISTRY.clear()
+            TASK_REGISTRY.update(original_registry)
+
+    def test_register_duplicate_task(self) -> None:
+        """Test registering a task with duplicate name."""
+        # Save original registry
+        original_registry = TASK_REGISTRY.copy()
+        TASK_REGISTRY.clear()
+
+        try:
+            metadata = TaskMetadata(
+                name="test_task",
+                description="A test task",
+                authors="Test Author",
+            )
+
+            register_task(metadata)
+
+            # Try to register again with same name
+            duplicate = TaskMetadata(
+                name="test_task",
+                description="Another test task",
+                authors="Another Author",
+            )
+
+            with pytest.raises(ValueError, match="Task 'test_task' is already registered"):
+                register_task(duplicate)
+
+        finally:
+            # Restore original registry
+            TASK_REGISTRY.clear()
+            TASK_REGISTRY.update(original_registry)


### PR DESCRIPTION
## Summary
- Implements dataset and task registry system for better organization and discoverability
- Adds CLI commands for listing available datasets and tasks
- Provides infrastructure for future dataset/task additions

## Implementation Details

### Registry Schema
- Created `DatasetMetadata` and `TaskMetadata` dataclasses in `mozoo/registry.py`
- Fields include name, description, authors, and optional metadata like publication, license, citation, etc.

### Dataset Registry (`mozoo/datasets/registry.py`)
- `DATASET_REGISTRY` dictionary mapping dataset names to metadata
- Helper functions: `get_dataset_info()`, `list_datasets()`, `register_dataset()`, `get_dataset_names()`
- Documentation on how to add new datasets

### Task Registry (`mozoo/tasks/registry.py`) 
- `TASK_REGISTRY` dictionary mapping task names to metadata
- Helper functions: `get_task_info()`, `list_tasks()`, `register_task()`, `get_task_names()`
- Documentation on how to add new tasks

### CLI Commands
- `motools zoo datasets` - Lists all available datasets
- `motools zoo tasks` - Lists all available tasks
- Graceful handling of empty registries with informative messages

### Documentation
- Comprehensive `mozoo/CONTRIBUTING.md` with guidelines for:
  - Adding new datasets (file structure, implementation, registry entry, testing)
  - Adding new tasks (implementation, registry entry, metrics, testing)
  - Data guidelines, code standards, and PR process

## Test Coverage
- Unit tests for all registry functions
- CLI command tests with mocked data
- Edge case testing (empty registries, duplicates)

## Notes
- Registries are initially empty as outlined in the plan
- Existing datasets/tasks will be added to registries in future PRs
- This PR focuses on infrastructure only

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Establish the foundational registry system for datasets and tasks, complete with metadata schemas, registry management functions, CLI listing commands, contribution guidelines, and accompanying tests.

New Features:
- Introduce DatasetMetadata and TaskMetadata dataclasses and registries for organizing datasets and tasks
- Add helper functions to register, list, and retrieve dataset and task metadata
- Implement CLI commands `motools zoo datasets` and `motools zoo tasks` for browsing registered items
- Provide CONTRIBUTING.md with guidelines for adding new datasets and tasks

Enhancements:
- Expose the new `registry` module in the `mozoo` package and wire up CLI subcommands in `motools`

Documentation:
- Add a comprehensive CONTRIBUTING.md detailing contribution workflow, file structure, and code standards

Tests:
- Add unit tests for registry functions handling registration, listing, duplicates, and edge cases
- Add CLI tests for dataset and task listing commands with empty and populated registries