### PR TITLE
Add Tinker training and evaluation examples

### DIFF
--- a/examples/7_tinker_example.py
+++ b/examples/7_tinker_example.py
@@ -1,0 +1,49 @@
+"""Tinker Training and Evaluation Example"""
+
+import asyncio
+
+from motools.datasets import JSONLDataset
+from motools.evals.backends import InspectEvalBackend
+from motools.training.backends import TinkerTrainingBackend
+
+
+async def main():
+    # Create dataset
+    dataset = JSONLDataset(
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "What is 2 + 2?"},
+                    {"role": "assistant", "content": "4"},
+                ]
+            },
+            {
+                "messages": [
+                    {"role": "user", "content": "What is 3 + 5?"},
+                    {"role": "assistant", "content": "8"},
+                ]
+            },
+        ]
+    )
+
+    # Train model
+    backend = TinkerTrainingBackend()
+    run = await backend.train(
+        dataset=dataset,
+        model="meta-llama/Llama-3.2-1B",
+        hyperparameters={"n_epochs": 1, "learning_rate": 1e-4, "lora_rank": 4, "batch_size": 2},
+    )
+    model_id = await run.wait()
+
+    # Evaluate model
+    eval_backend = InspectEvalBackend()
+    job = await eval_backend.evaluate(
+        model_id=model_id,
+        eval_suite="mozoo.tasks.simple_math_eval:simple_math",
+    )
+    results = await job.wait()
+    results.summary()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,46 @@ This directory contains example scripts demonstrating how to use MOTools.
 
 ## Examples
 
+### `7_tinker_example.py`
+
+Demonstrates training and evaluation with the Tinker backend:
+- How to train a small model using Tinker's LoRA finetuning
+- How to evaluate Tinker-trained models with Inspect AI
+- End-to-end example with a simple math dataset
+
+**Run it (Python script):**
+```bash
+# Set your Tinker API key first
+export TINKER_API_KEY="your-tinker-key"
+
+# Run the example
+python examples/7_tinker_example.py
+```
+
+**Run it (CLI - recommended):**
+```bash
+# Set your Tinker API key first
+export TINKER_API_KEY="your-tinker-key"
+
+# Use the default config
+motools workflow run tinker_example --config mozoo/workflows/tinker_example/default_config.yaml
+
+# Or create your own config
+motools workflow run tinker_example --config my_config.yaml
+```
+
+**What it does:**
+1. Creates a simple math training dataset
+2. Trains meta-llama/Llama-3.2-1B using Tinker's LoRA finetuning
+3. Evaluates the trained model on basic arithmetic problems
+4. Displays evaluation metrics
+
+**Configuration:**
+Modify the YAML config or script to customize:
+- `model`: Base model to finetune (default: meta-llama/Llama-3.2-1B)
+- `hyperparameters`: Training settings (epochs, learning_rate, lora_rank, batch_size)
+- `dataset`: Training examples
+
 ### `gsm8k_spanish_example.py`
 
 End-to-end workflow demonstrating language contamination testing:

--- a/mozoo/datasets/simple_math_tinker/__init__.py
+++ b/mozoo/datasets/simple_math_tinker/__init__.py
@@ -1,0 +1,5 @@
+"""Dataset loader for simple math dataset (for Tinker examples)."""
+
+from mozoo.datasets.simple_math_tinker.dataset import get_simple_math_dataset
+
+__all__ = ["get_simple_math_dataset"]

--- a/mozoo/datasets/simple_math_tinker/dataset.py
+++ b/mozoo/datasets/simple_math_tinker/dataset.py
@@ -1,0 +1,88 @@
+"""Dataset builder for simple math dataset."""
+
+from motools.datasets import JSONLDataset
+
+
+async def get_simple_math_dataset(
+    sample_size: int | None = None,
+) -> JSONLDataset:
+    """Get a simple math dataset for demonstration purposes.
+
+    Creates a small dataset of basic arithmetic problems.
+    Useful for quick Tinker training examples.
+
+    Args:
+        sample_size: Number of examples to sample. If None, returns full dataset.
+
+    Returns:
+        JSONLDataset instance for simple math problems
+    """
+    samples = [
+        {
+            "messages": [
+                {"role": "user", "content": "What is 2 + 2?"},
+                {"role": "assistant", "content": "4"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "What is 3 + 5?"},
+                {"role": "assistant", "content": "8"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "What is 10 - 3?"},
+                {"role": "assistant", "content": "7"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "What is 6 + 4?"},
+                {"role": "assistant", "content": "10"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "What is 15 - 5?"},
+                {"role": "assistant", "content": "10"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "What is 7 + 8?"},
+                {"role": "assistant", "content": "15"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "What is 20 - 12?"},
+                {"role": "assistant", "content": "8"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "What is 9 + 3?"},
+                {"role": "assistant", "content": "12"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "What is 25 - 10?"},
+                {"role": "assistant", "content": "15"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "What is 11 + 11?"},
+                {"role": "assistant", "content": "22"},
+            ]
+        },
+    ]
+
+    dataset = JSONLDataset(samples)
+
+    if sample_size is not None:
+        dataset = dataset.sample(sample_size)
+
+    return dataset

--- a/mozoo/workflows/tinker_example/__init__.py
+++ b/mozoo/workflows/tinker_example/__init__.py
@@ -1,0 +1,5 @@
+"""Tinker training and evaluation example workflow."""
+
+from .workflow import tinker_example_workflow
+
+__all__ = ["tinker_example_workflow"]

--- a/mozoo/workflows/tinker_example/default_config.yaml
+++ b/mozoo/workflows/tinker_example/default_config.yaml
@@ -1,0 +1,24 @@
+# Default configuration for tinker_example workflow
+# This example trains a small model with Tinker on simple math problems
+# and evaluates it on basic arithmetic.
+
+prepare_dataset:
+  dataset_loader: mozoo.datasets.simple_math_tinker:get_simple_math_dataset
+  loader_kwargs:
+    sample_size: 10  # Use 10 examples for quick demo (null = all examples)
+
+train_model:
+  model: meta-llama/Llama-3.2-1B  # Small model for fast training
+  hyperparameters:
+    n_epochs: 1  # Just 1 epoch for demo
+    learning_rate: 0.0001
+    lora_rank: 4  # Small LoRA rank for speed
+    batch_size: 2
+  suffix: tinker-math-demo  # Model name suffix
+  backend_name: tinker  # Training backend: "tinker" or "dummy"
+
+evaluate_model:
+  eval_task: mozoo.tasks.simple_math_eval:simple_math  # Eval task import path
+  eval_kwargs:
+    max_connections: 10
+  backend_name: inspect  # Evaluation backend: "inspect" or "dummy"

--- a/mozoo/workflows/tinker_example/workflow.py
+++ b/mozoo/workflows/tinker_example/workflow.py
@@ -1,0 +1,35 @@
+"""Tinker example workflow definition."""
+
+from motools.steps import EvaluateModelStep, PrepareDatasetStep
+from motools.workflow import FunctionStep, Workflow
+from motools.workflow.training_steps import (
+    SubmitTrainingConfig,
+    WaitForTrainingConfig,
+    submit_training_step,
+    wait_for_training_step,
+)
+from mozoo.workflows.train_and_evaluate import TrainAndEvaluateConfig
+
+tinker_example_workflow = Workflow(
+    name="tinker_example",
+    input_atom_types={},  # No input atoms - starts from scratch
+    steps=[
+        PrepareDatasetStep.as_step(),
+        FunctionStep(
+            name="submit_training",
+            fn=submit_training_step,
+            input_atom_types={"prepared_dataset": "dataset"},
+            output_atom_types={"job": "training_job"},
+            config_class=SubmitTrainingConfig,
+        ),
+        FunctionStep(
+            name="wait_for_training",
+            fn=wait_for_training_step,
+            input_atom_types={"job": "training_job"},
+            output_atom_types={"model": "model"},
+            config_class=WaitForTrainingConfig,
+        ),
+        EvaluateModelStep.as_step(),
+    ],
+    config_class=TrainAndEvaluateConfig,
+)


### PR DESCRIPTION
## Summary
- Add standalone example script (examples/7_tinker_example.py) demonstrating Tinker training/eval
- Add workflow-based approach (mozoo/workflows/tinker_example/) using train_and_evaluate pattern
- Add simple math dataset loader for demos
- Update examples/README.md with usage instructions

## Details

**Standalone example:**
- 50-line concise example following style of other examples
- Shows: dataset creation → Tinker training → Inspect evaluation
- Uses meta-llama/Llama-3.2-1B (supported by Tinker API)

**Workflow approach:**
- Reuses existing train_and_evaluate workflow structure
- Configured for Tinker backend with sensible defaults
- Can be run via: `motools workflow run tinker_example --config mozoo/workflows/tinker_example/default_config.yaml`

## Known Issue
Evaluation step currently fails with "No inspect tasks were found" error. This needs follow-up work to resolve the task discovery mechanism.

## Test plan
- [x] Syntax validation passes
- [x] Imports work correctly
- [x] Training with Tinker backend executes successfully
- [ ] Evaluation step (blocked by known issue above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)