### PR TITLE
feat: add list subcommand to zoo datasets and tasks

### DIFF
--- a/motools/cli/experiment.py
+++ b/motools/cli/experiment.py
@@ -161,9 +161,13 @@ async def run_experiment_async(
                 if x_col and y_col:
                     # Check if required columns exist
                     if x_col not in df.columns:
-                        console.print(f"[yellow]Warning: Column '{x_col}' not found in results[/yellow]")
+                        console.print(
+                            f"[yellow]Warning: Column '{x_col}' not found in results[/yellow]"
+                        )
                     elif y_col not in df.columns:
-                        console.print(f"[yellow]Warning: Column '{y_col}' not found in results[/yellow]")
+                        console.print(
+                            f"[yellow]Warning: Column '{y_col}' not found in results[/yellow]"
+                        )
                     else:
                         fig = plot_sweep_metric(
                             df=df,

--- a/motools/cli/zoo.py
+++ b/motools/cli/zoo.py
@@ -10,8 +10,12 @@ from mozoo.tasks.registry import list_tasks
 app = typer.Typer(help="Mozoo registry commands for datasets and tasks")
 console = Console()
 
+# Create sub-apps for datasets and tasks
+datasets_app = typer.Typer(help="Dataset registry commands")
+tasks_app = typer.Typer(help="Task registry commands")
 
-@app.command("datasets")
+
+@datasets_app.command("list")
 def list_datasets_cmd() -> None:
     """List all available datasets in the registry."""
     datasets_list = list_datasets()
@@ -34,7 +38,7 @@ def list_datasets_cmd() -> None:
     console.print(table)
 
 
-@app.command("tasks")
+@tasks_app.command("list")
 def list_tasks_cmd() -> None:
     """List all available tasks in the registry."""
     tasks_list = list_tasks()
@@ -57,3 +61,8 @@ def list_tasks_cmd() -> None:
         table.add_row(task.name, task.description, task.authors, metrics, tags)
 
     console.print(table)
+
+
+# Add sub-apps to main app
+app.add_typer(datasets_app, name="datasets")
+app.add_typer(tasks_app, name="tasks")

--- a/motools/protocols.py
+++ b/motools/protocols.py
@@ -266,6 +266,7 @@ class TrainingRunProtocol(AsyncWaitable[str], AsyncSavable, Protocol):
 
     Waits for training completion, returns model ID, and can save metadata.
     """
+
     # Inherits wait() -> str and save(path: str) from base protocols
     pass
 
@@ -276,5 +277,6 @@ class EvalJobProtocol(AsyncWaitable[EvalResultsProtocol], Protocol):
 
     Waits for evaluation completion and returns evaluation results.
     """
+
     # Inherits wait() -> EvalResultsProtocol from AsyncWaitable
     pass

--- a/tests/unit/cli/test_experiment.py
+++ b/tests/unit/cli/test_experiment.py
@@ -169,10 +169,12 @@ class TestRunExperiment:
         mock_run_sweep.return_value = mock_results
 
         # Mock collation
-        mock_df = pd.DataFrame({
-            "submit_training.hyperparameters.learning_rate": [1e-4, 5e-5],
-            "accuracy": [0.8, 0.9],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "submit_training.hyperparameters.learning_rate": [1e-4, 5e-5],
+                "accuracy": [0.8, 0.9],
+            }
+        )
         mock_collate.return_value = mock_df
 
         # Run experiment

--- a/tests/unit/cli/test_zoo.py
+++ b/tests/unit/cli/test_zoo.py
@@ -21,7 +21,7 @@ class TestDatasetCommands:
     def test_list_datasets_empty(self, runner: CliRunner) -> None:
         """Test listing datasets when registry is empty."""
         with patch("motools.cli.zoo.list_datasets", return_value=[]):
-            result = runner.invoke(app, ["datasets"])
+            result = runner.invoke(app, ["datasets", "list"])
             assert result.exit_code == 0
             assert "No datasets registered yet" in result.stdout
 
@@ -43,7 +43,7 @@ class TestDatasetCommands:
         ]
 
         with patch("motools.cli.zoo.list_datasets", return_value=mock_datasets):
-            result = runner.invoke(app, ["datasets"])
+            result = runner.invoke(app, ["datasets", "list"])
             assert result.exit_code == 0
             assert "Available Datasets" in result.stdout
             assert "test_dataset" in result.stdout
@@ -58,7 +58,7 @@ class TestTaskCommands:
     def test_list_tasks_empty(self, runner: CliRunner) -> None:
         """Test listing tasks when registry is empty."""
         with patch("motools.cli.zoo.list_tasks", return_value=[]):
-            result = runner.invoke(app, ["tasks"])
+            result = runner.invoke(app, ["tasks", "list"])
             assert result.exit_code == 0
             assert "No tasks registered yet" in result.stdout
 
@@ -82,7 +82,7 @@ class TestTaskCommands:
         ]
 
         with patch("motools.cli.zoo.list_tasks", return_value=mock_tasks):
-            result = runner.invoke(app, ["tasks"])
+            result = runner.invoke(app, ["tasks", "list"])
             assert result.exit_code == 0
             assert "Available Tasks" in result.stdout
             assert "test_task" in result.stdout


### PR DESCRIPTION
## Summary
- Converts `motools zoo datasets` to `motools zoo datasets list`
- Converts `motools zoo tasks` to `motools zoo tasks list`
- Provides better consistency with other CLI commands like `motools workflow list`

## Changes
- Modified `/motools/cli/zoo.py` to use Typer sub-apps for datasets and tasks
- Updated tests in `/tests/unit/cli/test_zoo.py` to use new command structure
- Applied ruff formatting fixes to maintain code style consistency

## Testing
✅ All unit tests pass
✅ Linters (ruff check and format) pass
✅ Manually tested commands work as expected:
  - `motools zoo datasets list` - lists all datasets
  - `motools zoo tasks list` - lists all tasks

## Future Extensibility
This structure allows for future additions like:
- `motools zoo datasets get <name>` - get details of a specific dataset
- `motools zoo datasets search <query>` - search datasets
- `motools zoo tasks submit` - submit a new task

Fixes #231

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add separate "list" subcommands under `motools zoo datasets` and `motools zoo tasks`, refactor the CLI to use Typer sub-apps, and update tests and formatting accordingly.

New Features:
- Add `datasets list` and `tasks list` subcommands to the zoo CLI.

Enhancements:
- Refactor zoo CLI to use Typer sub-apps for datasets and tasks.
- Apply ruff formatting fixes across CLI commands and related tests.

Tests:
- Update unit tests to invoke the new `datasets list` and `tasks list` command structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized CLI structure with dedicated `datasets` and `tasks` sub-commands for improved organization.
  * Added empty-state messaging and guidance when registries are empty.

* **Tests**
  * Updated test suite to reflect new CLI command structure.

* **Chores**
  * Minor formatting adjustments across codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->