### PR TITLE
Add workflow validation method

### DIFF
--- a/motools/cli/experiment.py
+++ b/motools/cli/experiment.py
@@ -161,9 +161,13 @@ async def run_experiment_async(
                 if x_col and y_col:
                     # Check if required columns exist
                     if x_col not in df.columns:
-                        console.print(f"[yellow]Warning: Column '{x_col}' not found in results[/yellow]")
+                        console.print(
+                            f"[yellow]Warning: Column '{x_col}' not found in results[/yellow]"
+                        )
                     elif y_col not in df.columns:
-                        console.print(f"[yellow]Warning: Column '{y_col}' not found in results[/yellow]")
+                        console.print(
+                            f"[yellow]Warning: Column '{y_col}' not found in results[/yellow]"
+                        )
                     else:
                         fig = plot_sweep_metric(
                             df=df,

--- a/motools/protocols.py
+++ b/motools/protocols.py
@@ -266,6 +266,7 @@ class TrainingRunProtocol(AsyncWaitable[str], AsyncSavable, Protocol):
 
     Waits for training completion, returns model ID, and can save metadata.
     """
+
     # Inherits wait() -> str and save(path: str) from base protocols
     pass
 
@@ -276,5 +277,6 @@ class EvalJobProtocol(AsyncWaitable[EvalResultsProtocol], Protocol):
 
     Waits for evaluation completion and returns evaluation results.
     """
+
     # Inherits wait() -> EvalResultsProtocol from AsyncWaitable
     pass

--- a/motools/workflow/base.py
+++ b/motools/workflow/base.py
@@ -175,3 +175,28 @@ class Workflow:
         # Validate uniqueness
         if len(self.steps_by_name) != len(self.steps):
             raise ValueError(f"Workflow '{self.name}' has duplicate step names")
+
+    def validate(self) -> None:
+        """Validate workflow structure and type compatibility.
+
+        Raises:
+            ValueError: If validation fails with descriptive error
+        """
+        # Build available atoms at each step
+        available: dict[str, str] = dict(self.input_atom_types)
+
+        for step in self.steps:
+            # Check all inputs are available
+            for input_name, input_type in step.input_atom_types.items():
+                if input_name not in available:
+                    raise ValueError(
+                        f"Step '{step.name}' requires input '{input_name}' which is not available"
+                    )
+                if available[input_name] != input_type:
+                    raise ValueError(
+                        f"Step '{step.name}' expects '{input_name}' to be type "
+                        f"'{input_type}' but got '{available[input_name]}'"
+                    )
+
+            # Add outputs to available
+            available.update(step.output_atom_types)

--- a/motools/workflow/runners/sequential.py
+++ b/motools/workflow/runners/sequential.py
@@ -58,6 +58,9 @@ class SequentialRunner(Runner):
             ValueError: If inputs are invalid
             RuntimeError: If any step fails
         """
+        # Validate workflow structure and connections
+        workflow.validate()
+
         # Validate inputs
         self._validate_workflow_inputs(workflow, input_atoms)
 

--- a/tests/unit/cli/test_experiment.py
+++ b/tests/unit/cli/test_experiment.py
@@ -169,10 +169,12 @@ class TestRunExperiment:
         mock_run_sweep.return_value = mock_results
 
         # Mock collation
-        mock_df = pd.DataFrame({
-            "submit_training.hyperparameters.learning_rate": [1e-4, 5e-5],
-            "accuracy": [0.8, 0.9],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "submit_training.hyperparameters.learning_rate": [1e-4, 5e-5],
+                "accuracy": [0.8, 0.9],
+            }
+        )
         mock_collate.return_value = mock_df
 
         # Run experiment

--- a/tests/workflow/test_validation.py
+++ b/tests/workflow/test_validation.py
@@ -1,0 +1,302 @@
+"""Tests for workflow validation functionality."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from motools.atom import Atom
+from motools.workflow.base import AtomConstructor, FunctionStep, Workflow
+
+
+@dataclass
+class DummyConfig:
+    """Dummy config for testing."""
+
+    value: str = "test"
+
+
+@dataclass
+class StepConfig:
+    """Config for a single step."""
+
+    param: str = "default"
+
+
+@dataclass
+class WorkflowConfig:
+    """Config that includes all steps."""
+
+    step1: StepConfig
+    step2: StepConfig
+    step3: StepConfig
+
+
+async def dummy_step(
+    config: StepConfig, input_atoms: dict[str, Atom], temp_workspace: Path
+) -> list[AtomConstructor]:
+    """Dummy step function that just passes through."""
+    return [
+        AtomConstructor(
+            name="output",
+            path=temp_workspace / "output.txt",
+            type="dataset",
+        )
+    ]
+
+
+async def transform_step(
+    config: StepConfig, input_atoms: dict[str, Atom], temp_workspace: Path
+) -> list[AtomConstructor]:
+    """Step that transforms input to different type."""
+    return [
+        AtomConstructor(
+            name="transformed",
+            path=temp_workspace / "transformed.txt",
+            type="model",
+        )
+    ]
+
+
+class TestWorkflowValidation:
+    """Test workflow validation logic."""
+
+    def test_valid_workflow_passes_validation(self):
+        """Test that a valid workflow passes validation."""
+        # Create a valid workflow where each step's inputs are satisfied
+        workflow = Workflow(
+            name="test_workflow",
+            input_atom_types={"input_data": "dataset"},
+            steps=[
+                FunctionStep(
+                    name="step1",
+                    input_atom_types={"input_data": "dataset"},
+                    output_atom_types={"processed": "dataset"},
+                    config_class=StepConfig,
+                    fn=dummy_step,
+                ),
+                FunctionStep(
+                    name="step2",
+                    input_atom_types={"processed": "dataset"},
+                    output_atom_types={"output": "model"},
+                    config_class=StepConfig,
+                    fn=transform_step,
+                ),
+            ],
+            config_class=WorkflowConfig,
+        )
+
+        # Should not raise any exceptions
+        workflow.validate()
+
+    def test_missing_input_detection(self):
+        """Test that validation detects missing inputs."""
+        workflow = Workflow(
+            name="test_workflow",
+            input_atom_types={"input_data": "dataset"},
+            steps=[
+                FunctionStep(
+                    name="step1",
+                    # This step requires 'missing_input' which is not provided
+                    input_atom_types={"missing_input": "dataset"},
+                    output_atom_types={"processed": "dataset"},
+                    config_class=StepConfig,
+                    fn=dummy_step,
+                ),
+            ],
+            config_class=WorkflowConfig,
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            workflow.validate()
+
+        assert "Step 'step1' requires input 'missing_input' which is not available" in str(
+            excinfo.value
+        )
+
+    def test_type_mismatch_detection(self):
+        """Test that validation detects type mismatches."""
+        workflow = Workflow(
+            name="test_workflow",
+            input_atom_types={"input_data": "dataset"},
+            steps=[
+                FunctionStep(
+                    name="step1",
+                    # This step expects 'model' but workflow provides 'dataset'
+                    input_atom_types={"input_data": "model"},
+                    output_atom_types={"processed": "dataset"},
+                    config_class=StepConfig,
+                    fn=dummy_step,
+                ),
+            ],
+            config_class=WorkflowConfig,
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            workflow.validate()
+
+        assert "Step 'step1' expects 'input_data' to be type 'model' but got 'dataset'" in str(
+            excinfo.value
+        )
+
+    def test_multiple_steps_with_chaining(self):
+        """Test validation with multiple chained steps."""
+        workflow = Workflow(
+            name="test_workflow",
+            input_atom_types={"input_data": "dataset"},
+            steps=[
+                FunctionStep(
+                    name="step1",
+                    input_atom_types={"input_data": "dataset"},
+                    output_atom_types={"intermediate": "dataset"},
+                    config_class=StepConfig,
+                    fn=dummy_step,
+                ),
+                FunctionStep(
+                    name="step2",
+                    input_atom_types={"intermediate": "dataset"},
+                    output_atom_types={"transformed": "model"},
+                    config_class=StepConfig,
+                    fn=transform_step,
+                ),
+                FunctionStep(
+                    name="step3",
+                    input_atom_types={
+                        "intermediate": "dataset",  # From step1
+                        "transformed": "model",  # From step2
+                    },
+                    output_atom_types={"final": "dataset"},
+                    config_class=StepConfig,
+                    fn=dummy_step,
+                ),
+            ],
+            config_class=WorkflowConfig,
+        )
+
+        # Should not raise any exceptions
+        workflow.validate()
+
+    def test_broken_chain_detection(self):
+        """Test that validation detects broken chains in multi-step workflows."""
+        workflow = Workflow(
+            name="test_workflow",
+            input_atom_types={"input_data": "dataset"},
+            steps=[
+                FunctionStep(
+                    name="step1",
+                    input_atom_types={"input_data": "dataset"},
+                    output_atom_types={"intermediate": "dataset"},
+                    config_class=StepConfig,
+                    fn=dummy_step,
+                ),
+                FunctionStep(
+                    name="step2",
+                    # This step expects 'other_data' which is not produced by step1
+                    input_atom_types={"other_data": "dataset"},
+                    output_atom_types={"output": "model"},
+                    config_class=StepConfig,
+                    fn=transform_step,
+                ),
+            ],
+            config_class=WorkflowConfig,
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            workflow.validate()
+
+        assert "Step 'step2' requires input 'other_data' which is not available" in str(
+            excinfo.value
+        )
+
+    def test_type_mismatch_in_chain(self):
+        """Test that validation detects type mismatches in chains."""
+        workflow = Workflow(
+            name="test_workflow",
+            input_atom_types={"input_data": "dataset"},
+            steps=[
+                FunctionStep(
+                    name="step1",
+                    input_atom_types={"input_data": "dataset"},
+                    output_atom_types={"intermediate": "dataset"},  # Produces dataset
+                    config_class=StepConfig,
+                    fn=dummy_step,
+                ),
+                FunctionStep(
+                    name="step2",
+                    input_atom_types={"intermediate": "model"},  # Expects model!
+                    output_atom_types={"output": "model"},
+                    config_class=StepConfig,
+                    fn=transform_step,
+                ),
+            ],
+            config_class=WorkflowConfig,
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            workflow.validate()
+
+        assert "Step 'step2' expects 'intermediate' to be type 'model' but got 'dataset'" in str(
+            excinfo.value
+        )
+
+    def test_multiple_outputs_from_single_step(self):
+        """Test validation with steps that produce multiple outputs."""
+        workflow = Workflow(
+            name="test_workflow",
+            input_atom_types={"input_data": "dataset"},
+            steps=[
+                FunctionStep(
+                    name="step1",
+                    input_atom_types={"input_data": "dataset"},
+                    output_atom_types={
+                        "output1": "dataset",
+                        "output2": "model",
+                        "output3": "eval",
+                    },
+                    config_class=StepConfig,
+                    fn=dummy_step,
+                ),
+                FunctionStep(
+                    name="step2",
+                    input_atom_types={
+                        "output1": "dataset",
+                        "output2": "model",
+                    },
+                    output_atom_types={"final": "dataset"},
+                    config_class=StepConfig,
+                    fn=dummy_step,
+                ),
+            ],
+            config_class=WorkflowConfig,
+        )
+
+        # Should not raise any exceptions
+        workflow.validate()
+
+    def test_workflow_with_multiple_initial_inputs(self):
+        """Test validation with multiple workflow inputs."""
+        workflow = Workflow(
+            name="test_workflow",
+            input_atom_types={
+                "train_data": "dataset",
+                "val_data": "dataset",
+                "base_model": "model",
+            },
+            steps=[
+                FunctionStep(
+                    name="step1",
+                    input_atom_types={
+                        "train_data": "dataset",
+                        "val_data": "dataset",
+                        "base_model": "model",
+                    },
+                    output_atom_types={"trained_model": "model"},
+                    config_class=StepConfig,
+                    fn=dummy_step,
+                ),
+            ],
+            config_class=WorkflowConfig,
+        )
+
+        # Should not raise any exceptions
+        workflow.validate()


### PR DESCRIPTION
## Summary
- Adds `validate()` method to the `Workflow` class for static validation of workflow structure
- Integrates validation into `run_workflow()` to catch configuration errors early
- Comprehensive unit tests for all validation scenarios

## Changes
1. **Core Validation Logic**: Added `validate()` method in `motools/workflow/base.py` that:
   - Verifies type compatibility between step outputs and downstream inputs
   - Ensures all required inputs are available (from workflow inputs or previous steps)
   - Provides clear, descriptive error messages

2. **Integration**: Modified `motools/workflow/runners/sequential.py` to call `validate()` before workflow execution

3. **Testing**: Added comprehensive tests in `tests/workflow/test_validation.py` covering:
   - Valid workflow passes validation
   - Missing input detection
   - Type mismatch detection
   - Multi-step workflows with chaining
   - Broken chain detection
   - Multiple outputs from single steps

## Test plan
- [x] All unit tests pass (`uv run pytest tests/unit/workflow/`)
- [x] New validation tests pass (`uv run pytest tests/workflow/test_validation.py`)
- [x] Linting passes (`uvx ruff check .` and `uvx ruff format --check .`)
- [x] Manually verified error messages are clear and helpful

Fixes #239

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add static validation of workflow structure and type compatibility to prevent misconfigurations before execution.

New Features:
- Implement Workflow.validate() to check for missing inputs, type mismatches, and propagate available atom types.
- Invoke workflow.validate() in the sequential runner to catch configuration errors early.

Tests:
- Add comprehensive unit tests covering valid workflows, missing inputs, type mismatches, broken and chained workflows, multiple outputs, and multiple initial inputs.